### PR TITLE
Implemented log to show current scanning file

### DIFF
--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -132,7 +132,6 @@ def validate_rules(rules_db: Dict[str, Any]) -> None:
         validate_ref_url(rule)
         validate_all_in_category(rule)
         validate_description_length(rule)
-    _log_info("Rules are valid!")
 
 
 def main(rules_db_path: str) -> None:

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -126,7 +126,6 @@ def validate_description_length(rule: Dict[str, Any]) -> None:
 
 def validate_rules(rules_db: Dict[str, Any]) -> None:
     """Validate rules from rules_db."""
-    _log_info("Validating rules...")
     validate_rules_db(rules_db)
     for rule_name, rule in rules_db["rules"].items():
         validate_rule_name(rule_name, rule)
@@ -140,6 +139,8 @@ def main(rules_db_path: str) -> None:
     """Validate the Rules DB file."""
     if rules_db_list := find_rules_db_yaml(rules_db_path):
         for rules_db_path in rules_db_list:
+            relarive_path = "/".join(rules_db_path.split("/")[-3:])
+            _log_info(f"Validating {relarive_path}")
             if rules_db := load_yaml_file(rules_db_path):
                 validate_rules(rules_db)
             else:

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -380,6 +380,27 @@ def test_main_with_empty_rules_db(
     )
 
 
+def test_main_with_error(
+    capfd: pytest.CaptureFixture[str], tmp_path: PosixPath
+) -> None:
+    """Test main with empty rules db."""
+    rules_db_path = tmp_path / "rules.yaml"
+    rules_db_path.write_text(_INVALID_RULES_DB_STRING_MISSING_CATEGORIES)
+    with pytest.raises(SystemExit):
+        main(str(tmp_path))
+    out, _ = capfd.readouterr()
+    assert re.match(
+        r"\n".join(
+            [
+                "^Validating .*/test_main_with_error0/rules.yaml",
+                "ERROR: Rules db is invalid: \"'categories' is a required property\"",
+                "$",
+            ]
+        ),
+        out,
+    )
+
+
 def test_main_with_without_rules_db(
     capfd: pytest.CaptureFixture[str], tmp_path: PosixPath
 ) -> None:

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -336,7 +336,7 @@ def test_validate_rules_with_valid_rules(
     requests_mock.get("http://my.link.com", status_code=200)
     validate_rules(yaml.safe_load(VALID_RULES_DB_STRING))
     out, _ = capfd.readouterr()
-    assert out == "Rules are valid!\n"
+    assert out == ""
 
 
 def test_main_with_valid_rules(
@@ -352,7 +352,6 @@ def test_main_with_valid_rules(
         r"\n".join(
             [
                 "^Validating .*/test_main_with_valid_rules0/rules.yaml",
-                "Rules are valid!",
                 "$",
             ]
         ),

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -1,4 +1,5 @@
 """Test."""
+import re
 from pathlib import PosixPath
 from uuid import uuid4
 
@@ -335,7 +336,7 @@ def test_validate_rules_with_valid_rules(
     requests_mock.get("http://my.link.com", status_code=200)
     validate_rules(yaml.safe_load(VALID_RULES_DB_STRING))
     out, _ = capfd.readouterr()
-    assert out == "Validating rules...\nRules are valid!\n"
+    assert out == "Rules are valid!\n"
 
 
 def test_main_with_valid_rules(
@@ -347,7 +348,16 @@ def test_main_with_valid_rules(
     rules_db_path.write_text(VALID_RULES_DB_STRING)
     main(str(tmp_path))
     out, _ = capfd.readouterr()
-    assert out == "Validating rules...\nRules are valid!\n"
+    assert re.match(
+        r"\n".join(
+            [
+                "^Validating .*/test_main_with_valid_rules0/rules.yaml",
+                "Rules are valid!",
+                "$",
+            ]
+        ),
+        out,
+    )
 
 
 def test_main_with_empty_rules_db(
@@ -359,7 +369,16 @@ def test_main_with_empty_rules_db(
     with pytest.raises(SystemExit):
         main(str(tmp_path))
     out, _ = capfd.readouterr()
-    assert out == "ERROR: Rules DB is empty\n"
+    assert re.match(
+        r"\n".join(
+            [
+                "^Validating .*/test_main_with_empty_rules_db0/rules.yaml",
+                "ERROR: Rules DB is empty",
+                "$",
+            ]
+        ),
+        out,
+    )
 
 
 def test_main_with_without_rules_db(


### PR DESCRIPTION
Current behavior:
- There is no information about the file that is being scanned. 
```
Validating rules...
Rules are valid!
Validating rules...
Rules are valid!
Validating rules...
ERROR: Rules db is invalid: \"'categories' is a required property\"
```

Expected behavior:
- The scanner informs what file is being scanned.
```
Validating boostsecurityio/brakeman-scanner/rules.yaml
Validating boostsecurityio/snyk-scanner/rules.yaml
Validating boostsecurityio/semgrep-scanner/rules.yaml
ERROR: Rules db is invalid: \"'categories' is a required property\"
```