### PR TITLE
Print all second and third column from git diff

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,8 @@ runs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: |
         git fetch --deepen=1 --quiet
-        git --no-pager diff --name-status HEAD~1 | awk '{print $2}' | \
+        git --no-pager diff --name-status HEAD~1 | \
+          awk '{ printf "%s\n%s\n", $2, $3 }' | \
           poetry run python -m boostsec.registry_validator.upload_rules_db \
           --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -48,10 +48,7 @@ runs:
     - name: Upload rules database
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: |
-        git fetch --deepen=1 --quiet
-        git --no-pager diff --name-status HEAD~1 | \
-          awk '{ printf "%s\n%s\n", $2, $3 }' | \
-          poetry run python -m boostsec.registry_validator.upload_rules_db \
+        poetry run python -m boostsec.registry_validator.upload_rules_db \
           --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }}
       shell: bash
       env:

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -45,7 +45,7 @@ def render_doc_url(unrendered_url: str) -> str:
 def find_modules() -> list[Path]:
     """Find module.yaml files."""
     fetch_command = ["git", "fetch", "--deepen=1", "--quiet"]
-    check_call(fetch_command)  # noqa: S603
+    check_call(fetch_command)  # noqa: S603 noboost
     diff_command = [
         "git",
         "--no-pager",
@@ -56,7 +56,7 @@ def find_modules() -> list[Path]:
         "AM",
         "HEAD~1",
     ]
-    diff_output = check_output(diff_command)  # noqa: S603
+    diff_output = check_output(diff_command)  # noqa: S603 noboost
     diff_output_list = diff_output.decode("utf-8").splitlines()
 
     modules_dic = {}

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import subprocess  # noqa: S404
 import sys
 from pathlib import Path
 from typing import Any
@@ -41,10 +42,25 @@ def render_doc_url(unrendered_url: str) -> str:
         return unrendered_url
 
 
-def find_modules(files_stdin: str) -> list[Path]:
+def find_modules() -> list[Path]:
     """Find module.yaml files."""
+    fetch_command = ["git", "fetch", "--deepen=1", "--quiet"]
+    subprocess.check_call(fetch_command)  # noqa: S603
+    diff_command = [
+        "git",
+        "--no-pager",
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter",
+        "AM",
+        "HEAD~1",
+    ]
+    diff_output = subprocess.check_output(diff_command)  # noqa: S603
+    diff_output_list = diff_output.decode("utf-8").splitlines()
+
     modules_dic = {}
-    for path in [i for i in files_stdin.splitlines() if i.endswith("yaml")]:
+    for path in [i for i in diff_output_list if i.endswith("yaml")]:
         module_path = Path(path).parent
         modules_dic[str(module_path)] = module_path
     return [i for i in modules_dic.values() if has_rules_yaml(i)]
@@ -118,9 +134,9 @@ def upload_rules_db(module: Path, api_endpoint: str, api_token: str) -> None:
         _log_error_and_exit(f"Unable to upload rules-db: {response.text}")
 
 
-def main(files_stdin: str, api_endpoint: str, api_token: str) -> None:
+def main(api_endpoint: str, api_token: str) -> None:
     """Validate the Rules DB file."""
-    modules = find_modules(files_stdin)
+    modules = find_modules()
     if len(modules) == 0:
         print("No module rules to update.")
     else:
@@ -143,4 +159,4 @@ if __name__ == "__main__":  # pragma: no cover
         required=True,
     )
     args = parser.parse_args()
-    main(sys.stdin.read(), **vars(args))
+    main(**vars(args))

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -2,9 +2,9 @@
 import argparse
 import json
 import os
-import subprocess  # noqa: S404
 import sys
 from pathlib import Path
+from subprocess import check_call, check_output  # noqa: S404
 from typing import Any
 from urllib.parse import urljoin
 
@@ -45,7 +45,7 @@ def render_doc_url(unrendered_url: str) -> str:
 def find_modules() -> list[Path]:
     """Find module.yaml files."""
     fetch_command = ["git", "fetch", "--deepen=1", "--quiet"]
-    subprocess.check_call(fetch_command)  # noqa: S603
+    check_call(fetch_command)  # noqa: S603
     diff_command = [
         "git",
         "--no-pager",
@@ -56,7 +56,7 @@ def find_modules() -> list[Path]:
         "AM",
         "HEAD~1",
     ]
-    diff_output = subprocess.check_output(diff_command)  # noqa: S603
+    diff_output = check_output(diff_command)  # noqa: S603
     diff_output_list = diff_output.decode("utf-8").splitlines()
 
     modules_dic = {}

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -218,11 +218,13 @@ def test_render_doc_url_no_placeholder() -> None:
     assert render_doc_url(test_url) == test_url
 
 
-@patch("boostsec.registry_validator.upload_rules_db.subprocess")
+@patch("boostsec.registry_validator.upload_rules_db.check_output")
+@patch("boostsec.registry_validator.upload_rules_db.check_call")
 @patch("boostsec.registry_validator.upload_rules_db.requests")
 def test_main_success(
     mock_requests: Any,
-    mock_subprocess: Any,
+    mock_check_call: Any,
+    mock_check_output: Any,
     capfd: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -232,7 +234,7 @@ def test_main_success(
     namespace = "namespace-example-main"
 
     module_path = _create_module_and_rules(tmp_path, VALID_RULES_DB_STRING, namespace)
-    mock_subprocess_decode = mock_subprocess.check_output.return_value.decode
+    mock_subprocess_decode = mock_check_output.return_value.decode
     mock_subprocess_decode.return_value.splitlines.return_value = [str(module_path)]
 
     main("https://my_endpoint/", "my-token")
@@ -242,11 +244,13 @@ def test_main_success(
     assert out == 'Uploading rules "namespace-example-main" "Example Scanner"...\n'
 
 
-@patch("boostsec.registry_validator.upload_rules_db.subprocess")
+@patch("boostsec.registry_validator.upload_rules_db.check_output")
+@patch("boostsec.registry_validator.upload_rules_db.check_call")
 @patch("boostsec.registry_validator.upload_rules_db.requests")
 def test_main_success_warning(
     mock_requests: Any,
-    mock_subprocess: Any,
+    mock_check_call: Any,
+    mock_check_output: Any,
     capfd: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -259,7 +263,7 @@ def test_main_success_warning(
     module2 = _create_module_and_rules(
         tmp_path, VALID_RULES_DB_STRING, "namespace-example-main2", create_rules=False
     )
-    mock_subprocess_decode = mock_subprocess.check_output.return_value.decode
+    mock_subprocess_decode = mock_check_output.return_value.decode
     mock_subprocess_decode.return_value.splitlines.return_value = [
         str(module1),
         str(module2),
@@ -272,16 +276,18 @@ def test_main_success_warning(
     assert "WARNING: rules.yaml not found in " in out
 
 
-@patch("boostsec.registry_validator.upload_rules_db.subprocess")
+@patch("boostsec.registry_validator.upload_rules_db.check_output")
+@patch("boostsec.registry_validator.upload_rules_db.check_call")
 @patch("boostsec.registry_validator.upload_rules_db.requests")
 def test_main_no_modules_to_update(
     mock_requests: Any,
-    mock_subprocess: Any,
+    mock_check_call: Any,
+    mock_check_output: Any,
     capfd: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
     """Test upload_rules_db."""
-    mock_subprocess_decode = mock_subprocess.check_output.return_value.decode
+    mock_subprocess_decode = mock_check_output.return_value.decode
     mock_subprocess_decode.return_value.splitlines.return_value = []
     main("https://my_endpoint/", "my-token")
 


### PR DESCRIPTION
There is a bug in the action when the file is moved with a commit. When it happens the second column on git diff is the old path and the third is the new path, example:
```
R089    old/path/module.yaml   new/path/module.yaml
R100    old/path/rules.yaml    new/path/rules.yaml
M       my/scanner/module.yaml
```
Since the action only used the second column the old path was passed to the script.
current behavior
```
old/path/module.yaml
my/scanner/module2.yaml
old/path/rules.yaml
my/scanner/module.yaml
```

This PR will take into consideration both the second and third column

```
old/path/module.yaml
new/path/module.yaml
my/scanner/module2.yaml

old/path/rules.yaml
new/path/rules.yaml
my/scanner/module.yaml

```
