### PR TITLE
BST-3554: Merge & upload imported rules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,8 @@ runs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       run: |
         poetry run python -m boostsec.registry_validator.upload_rules_db \
-          --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }}
+          --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }} \
+          --rules-db-path ${{ inputs.modules_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}

--- a/tests/unit/scanner/conftest.py
+++ b/tests/unit/scanner/conftest.py
@@ -1,0 +1,13 @@
+"""Scanner unit tests fixtures."""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def registry_path(tmp_path: Path) -> Path:
+    """Return a temporary registry directory."""
+    registry = tmp_path / "registry"
+    registry.mkdir(parents=True)
+
+    return registry

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -201,15 +201,6 @@ rules:
 """
 
 
-@pytest.fixture()
-def registry_path(tmp_path: Path) -> Path:
-    """Return a temporary registry directory."""
-    registry = tmp_path / "registry"
-    registry.mkdir(parents=True)
-
-    return registry
-
-
 def _create_module_rules(
     registry_path: Path, namespace: str, rules_db_string: str
 ) -> Path:


### PR DESCRIPTION
Rules can now be imported from other namespace. Imports are reference by the namespace name (ex: boost/module). If conflicting rule names are found, they get overwritten by the order defined in the file, giving the ability to update an imported rule.

Other changes:
 - Moved the `registry_path` fixture to conftest
 - Updated helper function to create module to include a namespace (useful for creating import tests)
 - Added a new cli input reference the registry path (identical to the validator). This is needed since import are only specified by a namespace, without it, we would have to guess the root folder of imported rules. It also simplifies testing.