### PR TITLE
fix: updated poetry to v1.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             - venv-0-main-
       - run:
           name: install poetry
-          command: pip3 install --pre "poetry==1.2.0b1"
+          command: pip3 install --pre "poetry==1.4.2"
       - run:
           command: make install
       - run:

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ runs:
       with:
         python-version: 3.9
     - name: Install poetry
-      run: pip3 install --pre "poetry==1.2.0b1"
+      run: pip3 install --pre "poetry==1.4.2"
       shell: bash
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,3 @@ minversion = "6.0"
 addopts = ["-p", "no:anyio", "-p", "asyncio"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-
-[build-system]
-# https://github.com/python-poetry/poetry/issues/4983
-requires = ["poetry-core>=1.1.0a6"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`poetry-core` recently had an update which is not compatible with the current poetry version (`1.2.0b1`). I think the issue was also caused by the `build-system` entry in `pyproject.toml` which would always get the latest version of `poetry-core`. 