### PR TITLE
BST-5645 - Bugfix to support legacy default namespace

### DIFF
--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -110,6 +110,8 @@ def _get_namespace_and_driver(module: Path) -> tuple[str, str]:
 
 
 def _get_rules(namespace: str, root: Path) -> RulesDB:
+    if namespace == "default":
+        namespace = "boostsecurityio/native-scanner"
     rules_db_path = root / namespace / "rules.yaml"
     rules_db_yaml = yaml.safe_load(rules_db_path.read_text())
     rules: RulesDB = {}

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -47,7 +47,16 @@ def _create_module_and_rules(
     return module_yaml
 
 
-def test_upload_rules_db(registry_path: Path, requests_mock: Mocker) -> None:
+@pytest.mark.parametrize(
+    "namespace",
+    [
+        "namespace-example",
+        "default",
+    ],
+)
+def test_upload_rules_db(
+    registry_path: Path, requests_mock: Mocker, namespace: str
+) -> None:
     """Test upload_rules_db."""
     url = "https://my_endpoint/"
     test_token = "my-random-key"  # noqa: S105
@@ -64,7 +73,11 @@ def test_upload_rules_db(registry_path: Path, requests_mock: Mocker) -> None:
         },
     )
 
-    namespace = "namespace-example"
+    _create_module_and_rules(
+        registry_path,
+        VALID_RULES_DB_STRING,
+        "boostsecurityio/native-scanner",  # Support legacy default scanner name
+    )
     module_path = _create_module_and_rules(
         registry_path, VALID_RULES_DB_STRING, namespace
     )
@@ -77,7 +90,7 @@ def test_upload_rules_db(registry_path: Path, requests_mock: Mocker) -> None:
         "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
         "variables": {
             "rules": {
-                "namespace": "namespace-example",
+                "namespace": namespace,
                 "ruleInputs": [
                     {
                         "categories": ["ALL", "category-1"],


### PR DESCRIPTION
I'm blocked from shipping this https://github.com/boostsecurityio/scanner-testing/actions/runs/5060855775/jobs/9084282167#step:3:299

This is a bugfix to support the legacy `default` namespace, which has a hardcoded mapping to the native-scanner module.