### PR TITLE
BST-5832: Import from rules realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ The authentication token for the boost backend.
 
 The path to the `module.yaml` file in the registry repo. Defaults to `scanners/`.
 
+### `rules_realm_path` (Optional, str)
+
+The path to the `rules.yaml` file in the registry repo. Defaults to `rules-realm/`.
+
 ### `docs_url` (Optional, str)
 
 The url for boost documentation. Defaults to `https://docs.boostsecurity.net`.

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: "Path to the modules directory"
     required: false
     default: "scanners/"
+  rules_realm_path:
+    description: "Path to the rules realm directory"
+    required: false
+    default: "rules-reaml/"
   docs_url:
     description: "URL to the documentation"
     required: false
@@ -40,7 +44,7 @@ runs:
       if: steps.changes.outputs.rules == 'true'
       run: |
         poetry run python -m boostsec.registry_validator.validate_rules_db \
-          --rules-db-path ${{ inputs.modules_path }}
+          --scanners-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -57,7 +61,7 @@ runs:
       run: |
         poetry run python -m boostsec.registry_validator.upload_rules_db \
           --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }} \
-          --rules-db-path ${{ inputs.modules_path }}
+          --scanners-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ inputs:
   rules_realm_path:
     description: "Path to the rules realm directory"
     required: false
-    default: "rules-reaml/"
+    default: "rules-realm/"
   docs_url:
     description: "URL to the documentation"
     required: false

--- a/boostsec/registry_validator/shared.py
+++ b/boostsec/registry_validator/shared.py
@@ -1,0 +1,14 @@
+"""Shared components between validation & uploads."""
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class RegistryConfig:
+    """Config class for the registry.
+
+    Holds reference to the scanners and rules realm location.
+    """
+
+    scanners_path: Path
+    rules_realm_path: Path

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -188,10 +188,12 @@ def upload_rules_db(
 
 
 def main(
-    api_endpoint: str, api_token: str, scanners_path: Path, rules_realm_path: Path
+    api_endpoint: str, api_token: str, scanners_path: str, rules_realm_path: str
 ) -> None:
     """Validate the Rules DB file."""
-    config = RegistryConfig(scanners_path, rules_realm_path)
+    config = RegistryConfig(
+        scanners_path=Path(scanners_path), rules_realm_path=Path(rules_realm_path)
+    )
     modules = find_modules()
     if len(modules) == 0:
         print("No module rules to update.")

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -199,10 +199,10 @@ def validate_rules(rules_db: Dict[str, Any], config: RegistryConfig) -> None:
         validate_imports(imports, config)
 
 
-def main(scanners_path: Path, rules_realm_path: Path) -> None:
+def main(scanners_path: str, rules_realm_path: str) -> None:
     """Validate the Rules DB file."""
     config = RegistryConfig(
-        scanners_path=scanners_path, rules_realm_path=rules_realm_path
+        scanners_path=Path(scanners_path), rules_realm_path=Path(rules_realm_path)
     )
     if rules_db_list := find_rules_db_yaml(config):
         for rules_db_path in rules_db_list:

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -1,14 +1,15 @@
 """Validates the Rules DB file."""
 import argparse
-import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import yaml
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
+from boostsec.registry_validator.shared import RegistryConfig
 from boostsec.registry_validator.upload_rules_db import render_doc_url
 
 RULES_SCHEMA = """
@@ -56,21 +57,29 @@ $defs:
 """
 
 
+@dataclass
+class RulesDbPath:
+    """Path to a RulesDB with the root path."""
+
+    root: Path
+    path: Path
+
+
 def _log_error_and_exit(message: str) -> None:
     """Log an error message and exit."""
     print("ERROR: " + message)
     sys.exit(1)
 
 
-def find_rules_db_yaml(rules_db_path: str) -> list[str]:
-    """Find module.yaml files."""
-    rules_db_list = []
-    for root, _, files in os.walk(rules_db_path):
-        for file in files:
-            if file.endswith("rules.yaml"):
-                file_path = os.path.join(root, file)
-                rules_db_list.append(file_path)
-    return rules_db_list
+def find_rules_db_yaml(config: RegistryConfig) -> list[RulesDbPath]:
+    """Find rules.yaml files."""
+    return [
+        RulesDbPath(root=config.scanners_path, path=path)
+        for path in config.scanners_path.rglob("rules.yaml")
+    ] + [
+        RulesDbPath(root=config.rules_realm_path, path=path)
+        for path in config.rules_realm_path.rglob("rules.yaml")
+    ]
 
 
 def _log_info(message: str) -> None:
@@ -78,12 +87,11 @@ def _log_info(message: str) -> None:
     print(message)
 
 
-def load_yaml_file(file_path: Union[str, Path]) -> Any:
+def load_yaml_file(file_path: Path) -> Any:
     """Load a YAML file."""
     try:
-        with open(file_path, "r") as file:
-            if rules_db := yaml.safe_load(file):
-                return rules_db
+        if rules_db := yaml.safe_load(file_path.read_text()):
+            return rules_db
     except FileNotFoundError:
         _log_error_and_exit(f"Rules DB not found: {file_path}")
     except yaml.YAMLError:
@@ -128,16 +136,16 @@ def validate_description_length(rule: Dict[str, Any]) -> None:
         )
 
 
-def validate_imports(imports: list[str], root: Path) -> None:
+def validate_imports(imports: list[str], config: RegistryConfig) -> None:
     """Validate the imports exists & not circular."""
     visited: set[str] = set()
     visited_stack: set[str] = set()
     for ns in imports:
-        _validate_imports(ns, visited, visited_stack, root)
+        _validate_imports(ns, visited, visited_stack, config)
 
 
 def _validate_imports(
-    namespace: str, visited: set[str], visited_stack: set[str], root: Path
+    namespace: str, visited: set[str], visited_stack: set[str], config: RegistryConfig
 ) -> None:
     """Recursively validate each namespace imports.
 
@@ -151,10 +159,19 @@ def _validate_imports(
         visited.add(namespace)
         visited_stack.add(namespace)
 
-    data = load_yaml_file(root / namespace / "rules.yaml")
+    scanner_path = config.scanners_path / namespace / "rules.yaml"
+    rules_realm_path = config.rules_realm_path / namespace / "rules.yaml"
+    data = {}
+    if scanner_path.exists():
+        data = load_yaml_file(scanner_path)
+    elif rules_realm_path.exists():
+        data = load_yaml_file(rules_realm_path)
+    else:
+        _log_error_and_exit(f"Imported namespace {namespace} not found")
+
     if imports := data.get("import"):
         for ns in imports:
-            _validate_imports(ns, visited, visited_stack, root)
+            _validate_imports(ns, visited, visited_stack, config)
 
     visited_stack.discard(namespace)
 
@@ -167,7 +184,7 @@ def _validate_rule(rule_name: str, rule: Dict[str, Any]) -> None:
     validate_description_length(rule)
 
 
-def validate_rules(rules_db: Dict[str, Any], root: Path) -> None:
+def validate_rules(rules_db: Dict[str, Any], config: RegistryConfig) -> None:
     """Validate rules from rules_db."""
     validate_rules_db(rules_db)
     for rule_name, rule in rules_db.get("rules", {}).items():
@@ -179,18 +196,21 @@ def validate_rules(rules_db: Dict[str, Any], root: Path) -> None:
         default_name, default_rule = default_items[0]
         _validate_rule(default_name, default_rule)
     if imports := rules_db.get("import"):
-        validate_imports(imports, root)
+        validate_imports(imports, config)
 
 
-def main(rules_db_path: str) -> None:
+def main(scanners_path: Path, rules_realm_path: Path) -> None:
     """Validate the Rules DB file."""
-    root = Path(rules_db_path)
-    if rules_db_list := find_rules_db_yaml(rules_db_path):
+    config = RegistryConfig(
+        scanners_path=scanners_path, rules_realm_path=rules_realm_path
+    )
+    if rules_db_list := find_rules_db_yaml(config):
         for rules_db_path in rules_db_list:
-            relative_path = Path(rules_db_path).relative_to(root)
-            _log_info(f"Validating {relative_path}")
-            if rules_db := load_yaml_file(rules_db_path):
-                validate_rules(rules_db, root)
+            _log_info(
+                f"Validating {rules_db_path.path.relative_to(rules_db_path.root)}"
+            )
+            if rules_db := load_yaml_file(rules_db_path.path):
+                validate_rules(rules_db, config)
             else:
                 _log_error_and_exit("Rules DB is empty")
     else:
@@ -200,9 +220,14 @@ def main(rules_db_path: str) -> None:
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(description="Process a rule database.")
     parser.add_argument(
+        "-s",
+        "--scanners-path",
+        help="The path of scanners.",
+    )
+    parser.add_argument(
         "-r",
-        "--rules-db-path",
-        help="The path of the rule database.",
+        "--rules-realm-path",
+        help="The path of rules realm.",
     )
     args = parser.parse_args()
     main(**vars(args))

--- a/tests/unit/scanner/conftest.py
+++ b/tests/unit/scanner/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from boostsec.registry_validator.shared import RegistryConfig
+
 
 @pytest.fixture()
 def registry_path(tmp_path: Path) -> Path:
@@ -11,3 +13,27 @@ def registry_path(tmp_path: Path) -> Path:
     registry.mkdir(parents=True)
 
     return registry
+
+
+@pytest.fixture()
+def scanners_path(registry_path: Path) -> Path:
+    """Return a temporary scanners directory."""
+    registry = registry_path / "scanners"
+    registry.mkdir(parents=True)
+
+    return registry
+
+
+@pytest.fixture()
+def rules_realm_path(registry_path: Path) -> Path:
+    """Return a temporary rules-realm directory."""
+    registry = registry_path / "rules-realm"
+    registry.mkdir(parents=True)
+
+    return registry
+
+
+@pytest.fixture()
+def registry_config(scanners_path: Path, rules_realm_path: Path) -> RegistryConfig:
+    """Return a RegistryConfig from valid temporary paths."""
+    return RegistryConfig(scanners_path, rules_realm_path)

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -469,7 +469,7 @@ def test_main_success(
     mock_subprocess_decode = mock_check_output.return_value.decode
     mock_subprocess_decode.return_value.splitlines.return_value = [str(module_path)]
 
-    main(url, "my-token", scanners_path, rules_realm_path)
+    main(url, "my-token", str(scanners_path), str(rules_realm_path))
 
     assert requests_mock.call_count == 1
     out, _ = capfd.readouterr()
@@ -509,7 +509,7 @@ def test_main_success_warning(
         str(module2),
     ]
 
-    main(url, "my-token", scanners_path, rules_realm_path)
+    main(url, "my-token", str(scanners_path), str(rules_realm_path))
 
     assert requests_mock.call_count == 1
     out, _ = capfd.readouterr()
@@ -529,7 +529,7 @@ def test_main_no_modules_to_update(
     """Test upload_rules_db."""
     mock_subprocess_decode = mock_check_output.return_value.decode
     mock_subprocess_decode.return_value.splitlines.return_value = []
-    main("https://my_endpoint/", "my-token", scanners_path, rules_realm_path)
+    main("https://my_endpoint/", "my-token", str(scanners_path), str(rules_realm_path))
 
     assert requests_mock.call_count == 0
     out, _ = capfd.readouterr()

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -566,7 +566,7 @@ def test_main_with_valid_rules(
     _create_module_rules(
         rules_realm_path, "namespace/realm-name", VALID_RULES_DB_STRING
     )
-    main(scanners_path, rules_realm_path)
+    main(str(scanners_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert (
         "Validating namespace/module-name/rules.yaml\n"
@@ -586,7 +586,7 @@ def test_main_with_valid_imports(
         VALID_RULES_DB_STRING_WITH_ONLY_IMPORT,
     )
     _create_module_rules(scanners_path, "namespace/module-a", VALID_RULES_DB_STRING)
-    main(scanners_path, rules_realm_path)
+    main(str(scanners_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert "Validating namespace/module-a/rules.yaml\n" in out
     assert "Validating testing-ns/testing-module/rules.yaml\n" in out
@@ -604,7 +604,7 @@ def test_main_with_valid_imports_from_realm(
         VALID_RULES_DB_STRING_WITH_ONLY_IMPORT,
     )
     _create_module_rules(rules_realm_path, "namespace/module-a", VALID_RULES_DB_STRING)
-    main(scanners_path, rules_realm_path)
+    main(str(scanners_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert "Validating namespace/module-a/rules.yaml\n" in out
     assert "Validating testing-ns/testing-module/rules.yaml\n" in out
@@ -622,7 +622,7 @@ def test_main_with_empty_rules_db(
         rules_realm_path if from_realm else scanners_path, "ns/empty", ""
     )
     with pytest.raises(SystemExit):
-        main(scanners_path, rules_realm_path)
+        main(str(scanners_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert "Validating ns/empty/rules.yaml\nERROR: Rules DB is empty\n" == out
 
@@ -654,7 +654,7 @@ def test_main_with_error(
         rules_realm_path if from_realm else scanners_path, "ns/invalid", rules_db_yaml
     )
     with pytest.raises(SystemExit):
-        main(scanners_path, rules_realm_path)
+        main(str(scanners_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert f"Validating ns/invalid/rules.yaml\n{expected}\n" == out
 
@@ -663,6 +663,6 @@ def test_main_with_without_rules_db(
     capfd: pytest.CaptureFixture[str], tmp_path: PosixPath
 ) -> None:
     """Test main with empty rules db."""
-    main(tmp_path, tmp_path)
+    main(str(tmp_path), str(tmp_path))
     out, _ = capfd.readouterr()
     assert out == "No Rules DB found\n"

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -1,12 +1,13 @@
 """Test."""
 from pathlib import Path, PosixPath
-from uuid import uuid4
 
 import pytest
 import yaml
 from _pytest.monkeypatch import MonkeyPatch
 
+from boostsec.registry_validator.shared import RegistryConfig
 from boostsec.registry_validator.validate_rules_db import (
+    RulesDbPath,
     find_rules_db_yaml,
     load_yaml_file,
     main,
@@ -275,42 +276,44 @@ def _create_module_rules(
     return module
 
 
-def _create_rules_db_yaml(tmp_path: PosixPath, rules_db_string: str) -> None:
-    """Create a module.yaml file."""
-    modules_path = tmp_path / uuid4().hex
-    modules_path.mkdir()
-    module_yaml = modules_path / "rules.yaml"
-    module_yaml.write_text(rules_db_string)
-
-
-def test_find_rules_db_yaml(tmp_path: PosixPath) -> None:
+def test_find_rules_db_yaml(registry_config: RegistryConfig) -> None:
     """Test find_rules_db_yaml."""
-    _create_rules_db_yaml(tmp_path, VALID_RULES_DB_STRING)
-    assert len(find_rules_db_yaml(str(tmp_path))) == 1
+    module = _create_module_rules(
+        registry_config.scanners_path, "namespace1", VALID_RULES_DB_STRING
+    )
+    realm = _create_module_rules(
+        registry_config.rules_realm_path, "namespace2", VALID_RULES_DB_STRING
+    )
+
+    result = find_rules_db_yaml(registry_config)
+    assert result == [
+        RulesDbPath(root=registry_config.scanners_path, path=module / "rules.yaml"),
+        RulesDbPath(root=registry_config.rules_realm_path, path=realm / "rules.yaml"),
+    ]
 
 
-def test_load_yaml_file(tmp_path: PosixPath) -> None:
+def test_load_yaml_file(tmp_path: Path) -> None:
     """Test load_yaml_file."""
     test_yaml = tmp_path / "test.yaml"
     test_yaml.write_text(VALID_RULES_DB_STRING)
-    assert load_yaml_file(str(test_yaml)) == yaml.safe_load(VALID_RULES_DB_STRING)
+    assert load_yaml_file(test_yaml) == yaml.safe_load(VALID_RULES_DB_STRING)
 
 
 def test_load_empty_yaml_file(tmp_path: PosixPath) -> None:
     """Test load_yaml_file with empty file."""
     test_yaml = tmp_path / "test.yaml"
     test_yaml.write_text("")
-    assert load_yaml_file(str(test_yaml)) == {}
+    assert load_yaml_file(test_yaml) == {}
 
 
 def test_load_yaml_file_with_invalid_yaml(
-    tmp_path: PosixPath, capfd: pytest.CaptureFixture[str]
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:
     """Test load_yaml_file with invalid yaml."""
     test_yaml = tmp_path / "test.yaml"
     test_yaml.write_text(_INVALID_YAML_FILE)
     with pytest.raises(SystemExit):
-        load_yaml_file(str(test_yaml))
+        load_yaml_file(test_yaml)
     out, _ = capfd.readouterr()
     assert out == "ERROR: Unable to parse Rules DB file\n"
 
@@ -318,7 +321,7 @@ def test_load_yaml_file_with_invalid_yaml(
 def test_load_yaml_without_file(capfd: pytest.CaptureFixture[str]) -> None:
     """Test load_yaml_file without file."""
     with pytest.raises(SystemExit):
-        load_yaml_file("/temp/does_not_exist.yaml")
+        load_yaml_file(Path("/temp/does_not_exist.yaml"))
     out, _ = capfd.readouterr()
     assert out == "ERROR: Rules DB not found: /temp/does_not_exist.yaml\n"
 
@@ -459,13 +462,19 @@ def test_validate_description_length_with_invalid_description(
     assert out == 'ERROR: Rule "test" has a description longer than 512 characters\n'
 
 
+def test_validate_imports_from_realm() -> None:
+    """Should be able to import rules from realm and vise-versa."""
+
+
+@pytest.mark.parametrize("from_realm", [True, False])
 def test_validate_imports_circular_import(
-    registry_path: Path,
     capfd: pytest.CaptureFixture[str],
+    registry_config: RegistryConfig,
+    from_realm: bool,
 ) -> None:
     """Should notify & exit if an import cycle is found."""
     _create_module_rules(
-        registry_path,
+        registry_config.scanners_path,
         "namespace1/module-a",
         """
         import:
@@ -474,7 +483,9 @@ def test_validate_imports_circular_import(
     )
 
     _create_module_rules(
-        registry_path,
+        registry_config.rules_realm_path
+        if from_realm
+        else registry_config.scanners_path,
         "namespace2/module-b",
         """
         import:
@@ -483,18 +494,22 @@ def test_validate_imports_circular_import(
     )
 
     with pytest.raises(SystemExit):
-        validate_imports(["namespace2/module-b"], registry_path)
+        validate_imports(["namespace2/module-b"], registry_config)
     out, _ = capfd.readouterr()
     assert out == "ERROR: Import cycle detected\n"
 
 
+@pytest.mark.parametrize("from_realm", [True, False])
 def test_validate_imports_missing_import(
-    registry_path: Path,
     capfd: pytest.CaptureFixture[str],
+    registry_config: RegistryConfig,
+    from_realm: bool,
 ) -> None:
     """Should notify & exit if an import doesn't exists."""
     _create_module_rules(
-        registry_path,
+        registry_config.rules_realm_path
+        if from_realm
+        else registry_config.scanners_path,
         "namespace/module-a",
         """
         import:
@@ -503,9 +518,9 @@ def test_validate_imports_missing_import(
     )
 
     with pytest.raises(SystemExit):
-        validate_imports(["namespace/module-a"], registry_path)
+        validate_imports(["namespace/module-a"], registry_config)
     out, _ = capfd.readouterr()
-    assert "ERROR: Rules DB not found" in out
+    assert "ERROR: Imported namespace namespace/module-b not found\n" in out
 
 
 @pytest.mark.parametrize(
@@ -520,11 +535,11 @@ def test_validate_imports_missing_import(
 def test_validate_rules_with_valid_rules(
     rules_db_yaml: str,
     capfd: pytest.CaptureFixture[str],
-    registry_path: Path,
+    registry_config: RegistryConfig,
 ) -> None:
     """Test validate_rules with valid rules."""
     _create_module_rules(
-        registry_path,
+        registry_config.scanners_path,
         "namespace/module-a",
         """
         import:
@@ -532,48 +547,82 @@ def test_validate_rules_with_valid_rules(
         """,
     )
     _create_module_rules(
-        registry_path,
+        registry_config.scanners_path,
         "namespace/module-b",
         VALID_RULES_DB_STRING,
     )
-    validate_rules(yaml.safe_load(rules_db_yaml), registry_path)
+    validate_rules(yaml.safe_load(rules_db_yaml), registry_config)
     out, _ = capfd.readouterr()
     assert out == ""
 
 
 def test_main_with_valid_rules(
-    capfd: pytest.CaptureFixture[str], registry_path: Path
+    capfd: pytest.CaptureFixture[str],
+    scanners_path: Path,
+    rules_realm_path: Path,
 ) -> None:
     """Test main with valid rules."""
-    _create_module_rules(registry_path, "namespace/module-name", VALID_RULES_DB_STRING)
-    main(str(registry_path))
+    _create_module_rules(scanners_path, "namespace/module-name", VALID_RULES_DB_STRING)
+    _create_module_rules(
+        rules_realm_path, "namespace/realm-name", VALID_RULES_DB_STRING
+    )
+    main(scanners_path, rules_realm_path)
     out, _ = capfd.readouterr()
-    assert "Validating namespace/module-name/rules.yaml\n" == out
+    assert (
+        "Validating namespace/module-name/rules.yaml\n"
+        "Validating namespace/realm-name/rules.yaml\n" == out
+    )
 
 
 def test_main_with_valid_imports(
-    capfd: pytest.CaptureFixture[str], registry_path: Path
+    capfd: pytest.CaptureFixture[str],
+    scanners_path: Path,
+    rules_realm_path: Path,
 ) -> None:
     """Test main with valid imported rules."""
     _create_module_rules(
-        registry_path,
+        scanners_path,
         "testing-ns/testing-module",
         VALID_RULES_DB_STRING_WITH_ONLY_IMPORT,
     )
-    _create_module_rules(registry_path, "namespace/module-a", VALID_RULES_DB_STRING)
-    main(str(registry_path))
+    _create_module_rules(scanners_path, "namespace/module-a", VALID_RULES_DB_STRING)
+    main(scanners_path, rules_realm_path)
     out, _ = capfd.readouterr()
     assert "Validating namespace/module-a/rules.yaml\n" in out
     assert "Validating testing-ns/testing-module/rules.yaml\n" in out
 
 
+def test_main_with_valid_imports_from_realm(
+    capfd: pytest.CaptureFixture[str],
+    scanners_path: Path,
+    rules_realm_path: Path,
+) -> None:
+    """Test main with valid imported rules."""
+    _create_module_rules(
+        scanners_path,
+        "testing-ns/testing-module",
+        VALID_RULES_DB_STRING_WITH_ONLY_IMPORT,
+    )
+    _create_module_rules(rules_realm_path, "namespace/module-a", VALID_RULES_DB_STRING)
+    main(scanners_path, rules_realm_path)
+    out, _ = capfd.readouterr()
+    assert "Validating namespace/module-a/rules.yaml\n" in out
+    assert "Validating testing-ns/testing-module/rules.yaml\n" in out
+
+
+@pytest.mark.parametrize("from_realm", [True, False])
 def test_main_with_empty_rules_db(
-    capfd: pytest.CaptureFixture[str], registry_path: Path
+    capfd: pytest.CaptureFixture[str],
+    scanners_path: Path,
+    rules_realm_path: Path,
+    from_realm: bool,
 ) -> None:
     """Test main with empty rules db."""
-    _create_module_rules(registry_path, "ns/empty", "")
+    _create_module_rules(
+        rules_realm_path if from_realm else scanners_path, "ns/empty", ""
+    )
     with pytest.raises(SystemExit):
-        main(str(registry_path))
+        main(scanners_path, rules_realm_path)
     out, _ = capfd.readouterr()
     assert "Validating ns/empty/rules.yaml\nERROR: Rules DB is empty\n" == out
 
@@ -591,16 +640,21 @@ def test_main_with_empty_rules_db(
         ),
     ],
 )
+@pytest.mark.parametrize("from_realm", [True, False])
 def test_main_with_error(
     capfd: pytest.CaptureFixture[str],
-    registry_path: Path,
     rules_db_yaml: str,
+    scanners_path: Path,
+    rules_realm_path: Path,
     expected: str,
+    from_realm: bool,
 ) -> None:
     """Test main with empty rules db."""
-    _create_module_rules(registry_path, "ns/invalid", rules_db_yaml)
+    _create_module_rules(
+        rules_realm_path if from_realm else scanners_path, "ns/invalid", rules_db_yaml
+    )
     with pytest.raises(SystemExit):
-        main(str(registry_path))
+        main(scanners_path, rules_realm_path)
     out, _ = capfd.readouterr()
     assert f"Validating ns/invalid/rules.yaml\n{expected}\n" == out
 
@@ -609,6 +663,6 @@ def test_main_with_without_rules_db(
     capfd: pytest.CaptureFixture[str], tmp_path: PosixPath
 ) -> None:
     """Test main with empty rules db."""
-    main(str(tmp_path))
+    main(tmp_path, tmp_path)
     out, _ = capfd.readouterr()
     assert out == "No Rules DB found\n"


### PR DESCRIPTION
Rules realm are similar to scanners, but they do not require to be defined as part of a scanner module. They are also defined by namespace, so the validate & upload steps now needs a reference to the scanners and realm location.

Next, I will add some validation to enforce the uniqueness between scanners & rules-realm.