### PR TITLE
BST-5833: Validate unique namespace between rules realm & modules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
     - name: Validate namespaces
       run: |
         poetry run python -m boostsec.registry_validator.validate_namespaces \
-          --modules-path ${{ inputs.modules_path }}
+          --modules-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}

--- a/tests/unit/scanner/test_validate_namespaces.py
+++ b/tests/unit/scanner/test_validate_namespaces.py
@@ -1,5 +1,6 @@
 """Test."""
 import re
+from functools import partial
 from pathlib import Path
 from uuid import uuid4
 
@@ -8,8 +9,11 @@ import yaml
 
 from boostsec.registry_validator.validate_namespaces import (
     find_module_yaml,
+    find_rules_realm_namespace,
+    get_module_namespaces,
     main,
-    validate_namespaces_from_modules_yaml,
+    validate_namespaces,
+    validate_unique_namepsace,
 )
 
 
@@ -30,6 +34,13 @@ def _create_module_yaml(tmp_path: Path, namespace: str = "") -> None:
     if namespace:
         module_obj["namespace"] = namespace
     module_yaml.write_text(yaml.dump(module_obj))
+
+
+def _create_rules_realm(tmp_path: Path, namespace: str) -> None:
+    realm_path = tmp_path / namespace
+    realm_path.mkdir(parents=True)
+    rule_yaml = realm_path / "rules.yaml"
+    rule_yaml.touch()
 
 
 @pytest.fixture()
@@ -56,27 +67,107 @@ def test_find_module_yaml(create_unique_modules: Path) -> None:
     assert len(modules) == 3
 
 
-def test_validate_namespaces_from_module_yaml(create_unique_modules: Path) -> None:
+def test_find_rules_realm_namespace(rules_realm_path: Path) -> None:
+    """Should return the namespaces relative to rules realm base."""
+    namespaces = ["ns/test1", "ns/deep/test2", "test3"]
+    for name in namespaces:
+        _create_rules_realm(rules_realm_path, name)
+
+    assert sorted(find_rules_realm_namespace(rules_realm_path)) == sorted(namespaces)
+
+
+def test_get_module_namespaces(create_unique_modules: Path) -> None:
+    """Should return the namespaces from the modules.yaml files."""
+    modules = find_module_yaml(str(create_unique_modules))
+    assert sorted(get_module_namespaces(modules)) == sorted(["test1", "test2", "test3"])
+
+
+@pytest.mark.parametrize(
+    ("namespaces", "unique", "expected"),
+    [
+        ([], True, ""),
+        (["test1", "test2", "test3"], True, ""),
+        (
+            ["test1", "test1"],
+            False,
+            "ERROR: namespaces are not unique, duplicate: test1\n",
+        ),
+    ],
+)
+def test_validate_unique_namepsace(
+    namespaces: list[str],
+    unique: bool,
+    expected: str,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Should error is duplicate values in namespaces."""
+    call = partial(validate_unique_namepsace, namespaces)
+    if unique:
+        call()
+    else:
+        with pytest.raises(SystemExit):
+            call()
+
+    out, _ = capfd.readouterr()
+    assert expected == out
+
+
+def test_validate_namespaces(create_unique_modules: Path) -> None:
     """Test validate_namespaces_from_module_yaml."""
     modules = find_module_yaml(str(create_unique_modules))
-    validate_namespaces_from_modules_yaml(modules)
+    validate_namespaces(modules, [])
 
 
-def test_validate_namespaces_from_module_yaml_without_namespace(
+def test_validate_namespaces_without_namespace(
     tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:
     """Test validate_namespaces_from_module_yaml."""
     _create_module_yaml(tmp_path)
     modules = find_module_yaml(str(tmp_path))
     with pytest.raises(SystemExit):
-        validate_namespaces_from_modules_yaml(modules)
+        validate_namespaces(modules, [])
     out, _ = capfd.readouterr()
     assert "ERROR: namespace not found in" in out
 
 
-def test_main(create_unique_modules: Path, capfd: pytest.CaptureFixture[str]) -> None:
+@pytest.mark.parametrize(
+    ("rules_ns", "unique", "expected"),
+    [
+        ([], True, ""),
+        (["test4", "test5"], True, ""),
+        (["test1"], False, "ERROR: namespaces are not unique, duplicate: test1\n"),
+    ],
+)
+def test_validate_namespaces_with_rules_realm(
+    create_unique_modules: Path,
+    rules_ns: list[str],
+    unique: bool,
+    expected: str,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Should identify duplicate between modules & rules realm."""
+    modules = find_module_yaml(str(create_unique_modules))
+
+    call = partial(validate_namespaces, modules, rules_ns)
+    if unique:
+        call()
+    else:
+        with pytest.raises(SystemExit):
+            call()
+
+    out, _ = capfd.readouterr()
+    assert expected == out
+
+
+def test_main(
+    create_unique_modules: Path,
+    rules_realm_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
     """Test main."""
-    main(str(create_unique_modules))
+    _create_rules_realm(rules_realm_path, "rules-ns")
+
+    main(str(create_unique_modules), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert out == "\n".join(
         [
@@ -88,11 +179,13 @@ def test_main(create_unique_modules: Path, capfd: pytest.CaptureFixture[str]) ->
 
 
 def test_main_error(
-    create_repeated_modules: Path, capfd: pytest.CaptureFixture[str]
+    create_repeated_modules: Path,
+    rules_realm_path: Path,
+    capfd: pytest.CaptureFixture[str],
 ) -> None:
     """Test main with repeated namespaces."""
     with pytest.raises(SystemExit):
-        main(str(create_repeated_modules))
+        main(str(create_repeated_modules), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert out == "\n".join(
         [
@@ -103,10 +196,31 @@ def test_main_error(
     )
 
 
-def test_main_invalid_module(tmp_path: Path, capfd: pytest.CaptureFixture[str]) -> None:
+def test_main_invalid_module(
+    tmp_path: Path, rules_realm_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
     """Test main with repeated namespaces."""
     _create_module_yaml(tmp_path)
     with pytest.raises(SystemExit):
-        main(str(tmp_path))
+        main(str(tmp_path), str(rules_realm_path))
     out, _ = capfd.readouterr()
     assert len(re.findall(r"ERROR: .* is a required property in", out)) == 1
+
+
+def test_main_with_module_rules_duplicate(
+    create_unique_modules: Path,
+    rules_realm_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Test main with duplicate namespace in module & rules realm."""
+    _create_rules_realm(rules_realm_path, "test1")
+    with pytest.raises(SystemExit):
+        main(str(create_unique_modules), str(rules_realm_path))
+    out, _ = capfd.readouterr()
+    assert out == "\n".join(
+        [
+            "Validating namespaces...",
+            "ERROR: namespaces are not unique, duplicate: test1",
+            "",
+        ]
+    )


### PR DESCRIPTION
Added validation to enforce that a namespace is unique between the rules realm & the scanner modules. The path relative to the rules realm base folder is used as a namespace.