### PR TITLE
BST-5922: Fix imported default ignored

### DIFF
--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -136,8 +136,9 @@ def _get_rules_and_default(
     default_rule = None
     if imports := rules_db_yaml.get("import"):
         for ns in imports:
-            import_rules, _ = _get_rules_and_default(ns, config)
+            import_rules, imported_default = _get_rules_and_default(ns, config)
             rules.update(import_rules)
+            default_rule = imported_default or default_rule
 
     if module_rules := rules_db_yaml.get("rules"):
         rules.update(module_rules)


### PR DESCRIPTION
Like regular rules, default rule can be imported, and the latest imported one should take precedence over the others. In the previous version, any import default would just get ignored.