### PR TITLE
BST-5993: Moved rules validations inside rules models

### DIFF
--- a/boostsec/registry_validator/shared.py
+++ b/boostsec/registry_validator/shared.py
@@ -1,19 +1,65 @@
 """Shared components between validation & uploads."""
+import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
+
+
+def render_doc_url(unrendered_url: str) -> str:
+    """Render doc url."""
+    var_name = "BOOSTSEC_DOC_BASE_URL"
+    placeholder = f"{{{var_name}}}"
+    if placeholder in unrendered_url:
+        doc_base_url = os.environ[var_name]
+        return unrendered_url.replace(placeholder, doc_base_url)
+    else:
+        return unrendered_url
 
 
 class RuleModel(BaseModel):
     """Representation of a scanner rule."""
 
-    categories: list[str]
-    description: str
-    group: str
     name: str
     pretty_name: str
+    description: str
+    group: str
+    categories: list[str]
     ref: str
+
+    class Config:
+        """Config."""
+
+        extra = "forbid"
+
+    @validator("categories")
+    def validate_all_in_category(cls, categories: list[str], values: Any) -> list[str]:
+        """Validate category ALL is included in the categories."""
+        if "ALL" not in categories:
+            name = values["name"]
+            raise ValueError(f'Rule "{name}" is missing category "ALL"')
+
+        return categories
+
+    @validator("description")
+    def validate_description_length(cls, description: str, values: Any) -> str:
+        """Validate rule description length is less than 512 characters."""
+        if len(description) > 512:
+            name = values["name"]
+            raise ValueError(
+                f'Rule "{name}" has a description longer than 512 characters'
+            )
+        return description
+
+    @validator("ref")
+    def validate_ref_url(cls, ref: str, values: Any) -> str:
+        """Validate ref url is valid."""
+        url = render_doc_url(ref)
+        if not url.startswith("http") and not url.startswith("https"):
+            name = values["name"]
+            raise ValueError(f'Url missing protocol: "{url}" from rule "{name}"')
+
+        return url
 
 
 Rules = dict[str, RuleModel]
@@ -25,6 +71,34 @@ class RulesDbModel(BaseModel):
     imports: Optional[list[str]] = Field(None, alias="import")
     rules: Optional[Rules]
     default: Optional[Rules]
+
+    @validator("rules")
+    def validate_rules_names(cls, rules: Optional[Rules]) -> Optional[Rules]:
+        """Validate rule name is equal to rule id."""
+        if not rules:
+            return None
+
+        for name, rule in rules.items():
+            if name != rule.name:
+                raise ValueError(f'Rule name "{name}" does not match "{rule.name}"')
+
+        return rules
+
+    @validator("default")
+    def validation_default(cls, default: Optional[Rules]) -> Optional[Rules]:
+        """Validate default rule."""
+        if not default:
+            return None
+
+        default_rules = list(default.items())
+        if len(default_rules) > 1:
+            raise ValueError("Only one default rule is allowed")
+
+        name, rule = default_rules[0]
+        if name != rule.name:
+            raise ValueError(f'Default rule name "{name}" does not match "{rule.name}"')
+
+        return default
 
 
 class RegistryConfig(BaseModel):

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -10,6 +10,7 @@ class RuleModelFactory(ModelFactory[RuleModel]):
     __model__ = RuleModel
 
     categories = Use(lambda: ["ALL"])
+    ref = Use(lambda: "https://example.org")
 
 
 class RuleDbModelFactory(ModelFactory[RulesDbModel]):

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -16,12 +16,7 @@ from boostsec.registry_validator.parameters import (
     RulesRealmPath,
     ScannersPath,
 )
-from boostsec.registry_validator.shared import (
-    RegistryConfig,
-    Rules,
-    RulesDbModel,
-    render_doc_url,
-)
+from boostsec.registry_validator.shared import RegistryConfig, Rules, RulesDbModel
 
 MUTATION = gql(
     """
@@ -99,7 +94,7 @@ def _get_variables(
                     "group": rule.group,
                     "name": rule.name,
                     "prettyName": rule.pretty_name,
-                    "ref": render_doc_url(rule.ref),
+                    "ref": rule.ref,
                 }
                 for rule in rules.values()
             ],

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -1,5 +1,4 @@
 """Uploads the Rules DB file."""
-import os
 import sys
 from pathlib import Path
 from subprocess import check_call, check_output  # noqa: S404
@@ -17,7 +16,12 @@ from boostsec.registry_validator.parameters import (
     RulesRealmPath,
     ScannersPath,
 )
-from boostsec.registry_validator.shared import RegistryConfig, Rules, RulesDbModel
+from boostsec.registry_validator.shared import (
+    RegistryConfig,
+    Rules,
+    RulesDbModel,
+    render_doc_url,
+)
 
 MUTATION = gql(
     """
@@ -41,17 +45,6 @@ def _log_error_and_exit(message: str) -> None:
     """Log an error message and exit."""
     print("ERROR: " + message)
     sys.exit(1)
-
-
-def render_doc_url(unrendered_url: str) -> str:
-    """Render doc url."""
-    var_name = "BOOSTSEC_DOC_BASE_URL"
-    placeholder = f"{{{var_name}}}"
-    if placeholder in unrendered_url:
-        doc_base_url = os.environ[var_name]
-        return unrendered_url.replace(placeholder, doc_base_url)
-    else:
-        return unrendered_url
 
 
 def find_updated_scanners(

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -15,7 +15,6 @@ from boostsec.registry_validator.shared import RegistryConfig
 from boostsec.registry_validator.upload_rules_db import (
     app,
     find_updated_scanners,
-    render_doc_url,
     upload_rules_db,
 )
 from tests.unit.scanner.test_validate_rules_db import (
@@ -630,27 +629,6 @@ def test_upload_rules_db_error_response(
             "",
         ]
     )
-
-
-def test_render_doc_url(monkeypatch: MonkeyPatch) -> None:
-    """Test render_doc_url."""
-    env_var_name = "BOOSTSEC_DOC_BASE_URL"
-    monkeypatch.setenv(env_var_name, "http://test.com")
-    rendered_url = render_doc_url(f"{{{env_var_name}}}/a/path")
-    assert rendered_url == "http://test.com/a/path"
-
-
-def test_render_doc_url_error_empty_env_var() -> None:
-    """Test render_doc_url."""
-    env_var_name = "BOOSTSEC_DOC_BASE_URL"
-    with pytest.raises(KeyError):
-        render_doc_url(f"{{{env_var_name}}}/a/path")
-
-
-def test_render_doc_url_no_placeholder() -> None:
-    """Test render_doc_url."""
-    test_url = "http://test.com/a/path"
-    assert render_doc_url(test_url) == test_url
 
 
 def test_find_updated_scanners(registry_path: Path, scanners_path: Path) -> None:

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -3,7 +3,6 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 
-from boostsec.registry_validator.shared import render_doc_url
 from boostsec.registry_validator.testing.factories import (
     RuleDbModelFactory,
     RuleModelFactory,
@@ -88,10 +87,7 @@ def test_validate_ref_url_with_valid_url(url: str) -> None:
 
 def test_validate_ref_url_with_invalid_url() -> None:
     """Should raises if ref is not a valid url."""
-    with pytest.raises(
-        ValidationError,
-        match='Url missing protocol: "invalid_url" from rule ".*"',
-    ):
+    with pytest.raises(ValidationError):
         RuleModelFactory.build(ref="invalid_url")
 
 
@@ -105,22 +101,8 @@ def test_validate_ref_url_with_valid_url_with_placeholder(
     assert rule.ref == "http://test.com/a/b/c"
 
 
-def test_render_doc_url(monkeypatch: MonkeyPatch) -> None:
-    """Test render_doc_url."""
-    env_var_name = "BOOSTSEC_DOC_BASE_URL"
-    monkeypatch.setenv(env_var_name, "http://test.com")
-    rendered_url = render_doc_url(f"{{{env_var_name}}}/a/path")
-    assert rendered_url == "http://test.com/a/path"
-
-
 def test_render_doc_url_error_empty_env_var() -> None:
     """Test render_doc_url."""
     env_var_name = "BOOSTSEC_DOC_BASE_URL"
     with pytest.raises(KeyError):
-        render_doc_url(f"{{{env_var_name}}}/a/path")
-
-
-def test_render_doc_url_no_placeholder() -> None:
-    """Test render_doc_url."""
-    test_url = "http://test.com/a/path"
-    assert render_doc_url(test_url) == test_url
+        RuleModelFactory.build(ref=f"{{{env_var_name}}}/a/path")

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -1,0 +1,126 @@
+"""Tests for shared module."""
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from pydantic import ValidationError
+
+from boostsec.registry_validator.shared import render_doc_url
+from boostsec.registry_validator.testing.factories import (
+    RuleDbModelFactory,
+    RuleModelFactory,
+)
+
+
+def test_validate_rule_name_with_valid_name() -> None:
+    """Test that each rule name matches its id."""
+    RuleDbModelFactory.build(
+        rules={
+            "rule-1": RuleModelFactory.build(name="rule-1"),
+            "rule-2": RuleModelFactory.build(name="rule-2"),
+        }
+    )
+
+
+def test_validate_rule_name_with_invalid_name() -> None:
+    """Should raise if rule name doesn't match its id."""
+    with pytest.raises(ValidationError, match='Rule name .* does not match ".*"'):
+        RuleDbModelFactory.build(rules={"test": RuleModelFactory.build(name="invalid")})
+
+
+def test_validate_rule_name_with_no_rules() -> None:
+    """Test rules db with no rules."""
+    RuleDbModelFactory.build()
+
+
+def test_validate_multiple_defaults() -> None:
+    """Should raises if multiple default rule."""
+    with pytest.raises(ValidationError, match="Only one default rule is allowed"):
+        RuleDbModelFactory.build(
+            default={
+                "rule-1": RuleModelFactory.build(name="rule-1"),
+                "rule-2": RuleModelFactory.build(name="rule-2"),
+            }
+        )
+
+
+def test_validate_default_invalid_name() -> None:
+    """Should raises if default rule as an invalid name."""
+    with pytest.raises(
+        ValidationError, match='Default rule name ".*" does not match ".*"'
+    ):
+        RuleDbModelFactory.build(
+            default={
+                "rule-1": RuleModelFactory.build(),
+            }
+        )
+
+
+def test_validate_all_in_category_with_valid_category() -> None:
+    """Test rule with valid category."""
+    RuleModelFactory.build(categories=["ALL"])
+
+
+def test_validate_all_in_category_with_invalid_category() -> None:
+    """Should raises if ALL is missing in categories."""
+    with pytest.raises(ValidationError, match='Rule .* is missing category "ALL"'):
+        RuleModelFactory.build(categories=["invalid"])
+
+
+def test_validate_description_length_with_valid_description() -> None:
+    """Test rule with valid description."""
+    RuleModelFactory.build(description="Lorem Ipsum " * 42)
+
+
+def test_validate_description_length_with_invalid_description() -> None:
+    """Should raises if rule description is too long."""
+    with pytest.raises(
+        ValidationError,
+        match="Rule .* has a description longer than 512 characters",
+    ):
+        RuleModelFactory.build(description="Lorem Ipsum " * 43)
+
+
+@pytest.mark.parametrize("url", ["https://example.com", "http://example.com"])
+def test_validate_ref_url_with_valid_url(url: str) -> None:
+    """Test rule with valid url."""
+    rule = RuleModelFactory.build(ref=url)
+    assert url == rule.ref
+
+
+def test_validate_ref_url_with_invalid_url() -> None:
+    """Should raises if ref is not a valid url."""
+    with pytest.raises(
+        ValidationError,
+        match='Url missing protocol: "invalid_url" from rule ".*"',
+    ):
+        RuleModelFactory.build(ref="invalid_url")
+
+
+def test_validate_ref_url_with_valid_url_with_placeholder(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test rule ref with env var injection."""
+    env_var_name = "BOOSTSEC_DOC_BASE_URL"
+    monkeypatch.setenv(env_var_name, "http://test.com")
+    rule = RuleModelFactory.build(ref=f"{{{env_var_name}}}/a/b/c")
+    assert rule.ref == "http://test.com/a/b/c"
+
+
+def test_render_doc_url(monkeypatch: MonkeyPatch) -> None:
+    """Test render_doc_url."""
+    env_var_name = "BOOSTSEC_DOC_BASE_URL"
+    monkeypatch.setenv(env_var_name, "http://test.com")
+    rendered_url = render_doc_url(f"{{{env_var_name}}}/a/path")
+    assert rendered_url == "http://test.com/a/path"
+
+
+def test_render_doc_url_error_empty_env_var() -> None:
+    """Test render_doc_url."""
+    env_var_name = "BOOSTSEC_DOC_BASE_URL"
+    with pytest.raises(KeyError):
+        render_doc_url(f"{{{env_var_name}}}/a/path")
+
+
+def test_render_doc_url_no_placeholder() -> None:
+    """Test render_doc_url."""
+    test_url = "http://test.com/a/path"
+    assert render_doc_url(test_url) == test_url


### PR DESCRIPTION
All the validations rules (except for the imports) were moved in the rules and rules db models. The corresponding validations tests were moved in the shared test file.

This changes also has the added bonus of logging the exact rule & field containing the error, rather than just logging that the whole file has an issue. (ex: `rules.my-rule-1.ref is missing`)

Since pydantic it now used to validate the models structure, the json schema was also removed.