### PR TITLE
BST-5993: Registry base path option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,14 +8,10 @@ inputs:
   api_token:
     description: "Boost API token"
     required: true
-  modules_path:
-    description: "Path to the modules directory"
+  registry_path:
+    description: "Registry base path."
     required: false
-    default: "scanners/"
-  rules_realm_path:
-    description: "Path to the rules realm directory"
-    required: false
-    default: "rules-realm/"
+    default: "."
   docs_url:
     description: "URL to the documentation"
     required: false
@@ -44,7 +40,7 @@ runs:
       if: steps.changes.outputs.rules == 'true'
       run: |
         poetry run python -m boostsec.registry_validator.validate_rules_db \
-          --scanners-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
+          --registry-path ${{ inputs.registry_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -52,7 +48,7 @@ runs:
     - name: Validate namespaces
       run: |
         poetry run python -m boostsec.registry_validator.validate_namespaces \
-          --modules-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
+          --registry-path ${{ inputs.registry_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}
@@ -61,7 +57,7 @@ runs:
       run: |
         poetry run python -m boostsec.registry_validator.upload_rules_db \
           --api-endpoint ${{ inputs.api_endpoint }} --api-token ${{ inputs.api_token }} \
-          --scanners-path ${{ inputs.modules_path }} --rules-realm-path ${{ inputs.rules_realm_path }}
+          --registry-path ${{ inputs.registry_path }}
       shell: bash
       env:
         PYTHONPATH: ${{ github.action_path }}

--- a/boostsec/registry_validator/parameters.py
+++ b/boostsec/registry_validator/parameters.py
@@ -4,6 +4,4 @@ import typer
 
 ApiEndpoint = typer.Option(help="The API endpoint to validate against.")
 ApiToken = typer.Option(help="The GitHub token to use for authentication.")
-ScannersPath = typer.Option(help="The path of scanners.")
-RulesRealmPath = typer.Option(help="The path of rules realm.")
-ModulesPath = typer.Option(help="The location of the rule database.")
+RegistryPath = typer.Option(help="The path of the registry.")

--- a/boostsec/registry_validator/shared.py
+++ b/boostsec/registry_validator/shared.py
@@ -94,6 +94,14 @@ class RegistryConfig(BaseModel):
     scanners_path: Path
     rules_realm_path: Path
 
+    @classmethod
+    def from_registry(cls, registry_path: Path) -> "RegistryConfig":
+        """Initialize a RegistryConfig from the base registry path."""
+        return cls(
+            scanners_path=registry_path / "scanners",
+            rules_realm_path=registry_path / "rules-realm",
+        )
+
 
 def _render_doc_url(unrendered_url: str) -> str:
     """Render doc url."""

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -10,12 +10,7 @@ import yaml
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
-from boostsec.registry_validator.parameters import (
-    ApiEndpoint,
-    ApiToken,
-    RulesRealmPath,
-    ScannersPath,
-)
+from boostsec.registry_validator.parameters import ApiEndpoint, ApiToken, RegistryPath
 from boostsec.registry_validator.shared import RegistryConfig, Rules, RulesDbModel
 
 MUTATION = gql(
@@ -191,13 +186,10 @@ def upload_rules_db(
 def main(
     api_endpoint: str = ApiEndpoint,
     api_token: str = ApiToken,
-    scanners_path: str = ScannersPath,
-    rules_realm_path: str = RulesRealmPath,
+    registry_path: Path = RegistryPath,
 ) -> None:
     """Process a rule database."""
-    config = RegistryConfig(
-        scanners_path=Path(scanners_path), rules_realm_path=Path(rules_realm_path)
-    )
+    config = RegistryConfig.from_registry(registry_path)
     modules = find_updated_scanners(config.scanners_path)
     if len(modules) == 0:
         print("No module rules to update.")

--- a/boostsec/registry_validator/validate_namespaces.py
+++ b/boostsec/registry_validator/validate_namespaces.py
@@ -7,7 +7,8 @@ import yaml
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
-from boostsec.registry_validator.parameters import ModulesPath, RulesRealmPath
+from boostsec.registry_validator.parameters import RegistryPath
+from boostsec.registry_validator.shared import RegistryConfig
 
 MODULE_SCHEMA = """
 type: object
@@ -47,10 +48,10 @@ def _log_error_and_exit(message: str) -> None:
     sys.exit(1)
 
 
-def find_module_yaml(modules_path: str) -> list[Path]:
+def find_module_yaml(modules_path: Path) -> list[Path]:
     """Find module.yaml files."""
     modules_list = []
-    for path in Path(modules_path).rglob("module.yaml"):
+    for path in modules_path.rglob("module.yaml"):
         modules_list.append(path)
     return modules_list
 
@@ -103,13 +104,13 @@ def validate_namespaces(modules_list: list[Path], rule_namespaces: list[str]) ->
 
 @app.command()
 def main(
-    modules_path: str = ModulesPath,
-    rules_realm_path: str = RulesRealmPath,
+    registry_path: Path = RegistryPath,
 ) -> None:
     """Validate that namespaces are unique."""
+    config = RegistryConfig.from_registry(registry_path)
     print("Validating namespaces...")
-    modules_list = find_module_yaml(modules_path)
-    rule_namespaces = find_rules_realm_namespace(Path(rules_realm_path))
+    modules_list = find_module_yaml(config.scanners_path)
+    rule_namespaces = find_rules_realm_namespace(config.rules_realm_path)
     for module in modules_list:
         validate_module_yaml_schema(module)
     validate_namespaces(modules_list, rule_namespaces)

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -7,7 +7,7 @@ import typer
 import yaml
 from pydantic import BaseModel, ValidationError
 
-from boostsec.registry_validator.parameters import RulesRealmPath, ScannersPath
+from boostsec.registry_validator.parameters import RegistryPath
 from boostsec.registry_validator.shared import RegistryConfig, RulesDbModel
 
 
@@ -131,14 +131,9 @@ def validate_rules(raw_rules_db: Dict[str, Any], config: RegistryConfig) -> None
 
 
 @app.command()
-def main(
-    scanners_path: str = ScannersPath,
-    rules_realm_path: str = RulesRealmPath,
-) -> None:
+def main(registry_path: Path = RegistryPath) -> None:
     """Validate the Rules DB file."""
-    config = RegistryConfig(
-        scanners_path=Path(scanners_path), rules_realm_path=Path(rules_realm_path)
-    )
+    config = RegistryConfig.from_registry(registry_path)
     if rules_db_list := find_rules_db_yaml(config):
         for rules_db_path in rules_db_list:
             _log_info(

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -707,8 +707,8 @@ def test_find_updated_scanners_ignore_rules_realm(
 def test_main_success(
     mock_check_output: Any,
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
-    rules_realm_path: Path,
     requests_mock: Mocker,
 ) -> None:
     """Test upload_rules_db."""
@@ -734,10 +734,8 @@ def test_main_success(
             "https://my_endpoint/",
             "--api-token",
             "my-token",
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
 
@@ -753,8 +751,8 @@ def test_main_success(
 def test_main_success_warning(
     mock_check_output: Any,
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
-    rules_realm_path: Path,
     requests_mock: Mocker,
 ) -> None:
     """Test upload_rules_db."""
@@ -787,10 +785,8 @@ def test_main_success_warning(
             "https://my_endpoint/",
             "--api-token",
             "my-token",
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
 
@@ -803,8 +799,7 @@ def test_main_success_warning(
 def test_main_no_modules_to_update(
     mock_check_output: Any,
     cli_runner: CliRunner,
-    scanners_path: Path,
-    rules_realm_path: Path,
+    registry_path: Path,
     requests_mock: Mocker,
 ) -> None:
     """Test upload_rules_db."""
@@ -818,10 +813,8 @@ def test_main_no_modules_to_update(
             "https://my_endpoint/",
             "--api-token",
             "my-token",
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
 
@@ -834,7 +827,7 @@ def test_main_no_modules_to_update(
 def test_main_only_rules_realm(
     mock_check_output: Any,
     cli_runner: CliRunner,
-    scanners_path: Path,
+    registry_path: Path,
     rules_realm_path: Path,
     requests_mock: Mocker,
 ) -> None:
@@ -851,10 +844,8 @@ def test_main_only_rules_realm(
             "https://my_endpoint/",
             "--api-token",
             "my-token",
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
 
@@ -867,6 +858,7 @@ def test_main_only_rules_realm(
 def test_main_only_rules_realm_with_module(
     mock_check_output: Any,
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
     rules_realm_path: Path,
     requests_mock: Mocker,
@@ -898,10 +890,8 @@ def test_main_only_rules_realm_with_module(
             "https://my_endpoint/",
             "--api-token",
             "my-token",
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
 

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -1,5 +1,5 @@
 """Test."""
-from pathlib import Path, PosixPath
+from pathlib import Path
 
 import pytest
 import yaml
@@ -283,7 +283,7 @@ def test_load_yaml_file(tmp_path: Path) -> None:
     assert load_yaml_file(test_yaml) == yaml.safe_load(VALID_RULES_DB_STRING)
 
 
-def test_load_empty_yaml_file(tmp_path: PosixPath) -> None:
+def test_load_empty_yaml_file(tmp_path: Path) -> None:
     """Test load_yaml_file with empty file."""
     test_yaml = tmp_path / "test.yaml"
     test_yaml.write_text("")
@@ -464,6 +464,7 @@ def test_validate_rules_with_valid_rules(
 
 def test_main_with_valid_rules(
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
     rules_realm_path: Path,
 ) -> None:
@@ -475,10 +476,8 @@ def test_main_with_valid_rules(
     result = cli_runner.invoke(
         app,
         [
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
     assert result.stdout == (
@@ -489,8 +488,8 @@ def test_main_with_valid_rules(
 
 def test_main_with_valid_imports(
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
-    rules_realm_path: Path,
 ) -> None:
     """Test main with valid imported rules."""
     _create_module_rules(
@@ -502,10 +501,8 @@ def test_main_with_valid_imports(
     result = cli_runner.invoke(
         app,
         [
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
     assert "Validating namespace/module-a/rules.yaml\n" in result.stdout
@@ -514,6 +511,7 @@ def test_main_with_valid_imports(
 
 def test_main_with_valid_imports_from_realm(
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
     rules_realm_path: Path,
 ) -> None:
@@ -527,10 +525,8 @@ def test_main_with_valid_imports_from_realm(
     result = cli_runner.invoke(
         app,
         [
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
     assert "Validating namespace/module-a/rules.yaml\n" in result.stdout
@@ -540,6 +536,7 @@ def test_main_with_valid_imports_from_realm(
 @pytest.mark.parametrize("from_realm", [True, False])
 def test_main_with_empty_rules_db(
     cli_runner: CliRunner,
+    registry_path: Path,
     scanners_path: Path,
     rules_realm_path: Path,
     from_realm: bool,
@@ -551,10 +548,8 @@ def test_main_with_empty_rules_db(
     result = cli_runner.invoke(
         app,
         [
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
     assert result.exit_code == 1
@@ -579,6 +574,7 @@ def test_main_with_empty_rules_db(
 def test_main_with_error(
     cli_runner: CliRunner,
     rules_db_yaml: str,
+    registry_path: Path,
     scanners_path: Path,
     rules_realm_path: Path,
     expected: str,
@@ -592,19 +588,15 @@ def test_main_with_error(
     result = cli_runner.invoke(
         app,
         [
-            "--scanners-path",
-            str(scanners_path),
-            "--rules-realm-path",
-            str(rules_realm_path),
+            "--registry-path",
+            str(registry_path),
         ],
     )
     assert result.exit_code == 1
     assert result.stdout == f"Validating ns/invalid/rules.yaml\n{expected}\n"
 
 
-def test_main_with_without_rules_db(cli_runner: CliRunner, tmp_path: PosixPath) -> None:
+def test_main_with_without_rules_db(cli_runner: CliRunner, registry_path: Path) -> None:
     """Test main with empty rules db."""
-    result = cli_runner.invoke(
-        app, ["--scanners-path", str(tmp_path), "--rules-realm-path", str(tmp_path)]
-    )
+    result = cli_runner.invoke(app, ["--registry-path", str(registry_path)])
     assert result.stdout == "No Rules DB found\n"

--- a/tests/unit/test_shared.py
+++ b/tests/unit/test_shared.py
@@ -1,8 +1,11 @@
 """Tests for shared module."""
+from pathlib import Path
+
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 
+from boostsec.registry_validator.shared import RegistryConfig
 from boostsec.registry_validator.testing.factories import (
     RuleDbModelFactory,
     RuleModelFactory,
@@ -106,3 +109,10 @@ def test_render_doc_url_error_empty_env_var() -> None:
     env_var_name = "BOOSTSEC_DOC_BASE_URL"
     with pytest.raises(KeyError):
         RuleModelFactory.build(ref=f"{{{env_var_name}}}/a/path")
+
+
+def test_registry_config_from_path(tmp_path: Path) -> None:
+    """Should init config from a registry base path."""
+    config = RegistryConfig.from_registry(tmp_path)
+    assert config.scanners_path == tmp_path / "scanners"
+    assert config.rules_realm_path == tmp_path / "rules-realm"


### PR DESCRIPTION
The CLI options to specify the module, scanners or rules-realm paths were replaced by a single option: registry-path. Now, the path of the scanners and rules-realm are derived from the provided base registry.

This was made in prevision of an upcoming change to the way updated modules/rules are tracked.