### PR TITLE
BST-5993: Detect updated dependencies

### DIFF
--- a/boostsec/registry_validator/config.py
+++ b/boostsec/registry_validator/config.py
@@ -1,0 +1,22 @@
+"""Scanners & rules config."""
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class RegistryConfig(BaseModel):
+    """Config class for the registry.
+
+    Holds reference to the scanners and rules realm location.
+    """
+
+    scanners_path: Path
+    rules_realm_path: Path
+
+    @classmethod
+    def from_registry(cls, registry_path: Path) -> "RegistryConfig":
+        """Initialize a RegistryConfig from the base registry path."""
+        return cls(
+            scanners_path=registry_path / "scanners",
+            rules_realm_path=registry_path / "rules-realm",
+        )

--- a/boostsec/registry_validator/models.py
+++ b/boostsec/registry_validator/models.py
@@ -1,0 +1,39 @@
+"""Models."""
+from enum import Enum
+from typing import Literal, Optional, Union
+
+from pydantic import BaseModel
+
+from boostsec.registry_validator.schema import RulesSchema
+
+
+class NamespaceType(str, Enum):
+    """Type of namespace."""
+
+    Scanner = "scanner"
+    RuleRealm = "rule-realm"
+
+
+class _NamespaceBase(BaseModel):
+    namespace: str
+    updated: bool = False
+    rules: RulesSchema = {}
+    imports: list[str] = []
+    default: Optional[RulesSchema] = None
+
+
+class ScannerNamespace(_NamespaceBase):
+    """Scanner namespace."""
+
+    namespace_type: Literal[NamespaceType.Scanner] = NamespaceType.Scanner
+
+    driver: str
+
+
+class RuleRealmNamespace(_NamespaceBase):
+    """Rule realm namespace."""
+
+    namespace_type: Literal[NamespaceType.RuleRealm] = NamespaceType.RuleRealm
+
+
+NamespaceUnion = Union[ScannerNamespace, RuleRealmNamespace]

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -1,23 +1,48 @@
 """Factories."""
+from typing import cast
+
 from pydantic_factories import ModelFactory, Use
 
-from boostsec.registry_validator.shared import RuleModel, RulesDbModel
+from boostsec.registry_validator.models import RuleRealmNamespace, ScannerNamespace
+from boostsec.registry_validator.schema import RuleSchema, RulesDbSchema
 
 
-class RuleModelFactory(ModelFactory[RuleModel]):
+class RuleSchemaFactory(ModelFactory[RuleSchema]):
     """Factory."""
 
-    __model__ = RuleModel
+    __model__ = RuleSchema
 
     categories = Use(lambda: ["ALL"])
     ref = Use(lambda: "https://example.org")
 
 
-class RuleDbModelFactory(ModelFactory[RulesDbModel]):
+class RulesDbSchemaFactory(ModelFactory[RulesDbSchema]):
     """Factory."""
 
-    __model__ = RulesDbModel
+    __model__ = RulesDbSchema
 
     imports = Use(lambda: None)
     rules = Use(lambda: None)
     default = Use(lambda: None)
+
+
+class ScannerNamespaceFactory(ModelFactory[ScannerNamespace]):
+    """Factory."""
+
+    __model__ = ScannerNamespace
+
+    rules = Use(lambda: cast(RuleSchema, {}))
+    imports = Use(lambda: cast(list[str], []))
+    default = Use(lambda: None)
+    updated = Use(lambda: False)
+
+
+class RuleRealmNamespaceFactory(ModelFactory[RuleRealmNamespace]):
+    """Factory."""
+
+    __model__ = RuleRealmNamespace
+
+    rules = Use(lambda: cast(RuleSchema, {}))
+    imports = Use(lambda: cast(list[str], []))
+    default = Use(lambda: None)
+    updated = Use(lambda: False)

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -276,7 +276,7 @@ def main(
         print("No module rules to update.")
         return None
 
-    for scanner in get_updated_scanners(scanners, namespace_cache):
+    for scanner in scanners_to_update:
         upload_rules_db(scanner, api_endpoint, api_token)
 
 

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -87,6 +87,9 @@ def load_scanners(scanners_path: Path, updated_ns: set[str]) -> list[ScannerName
             namespace = "boostsecurityio/native-scanner"
         driver = module_yaml["name"]
         rules_path = module_path.parent / "rules.yaml"
+        if not rules_path.exists():
+            print(f'WARNING: rules.yaml not found in "{namespace}". Skipping...')
+            continue
         rules_db_yaml = yaml.safe_load(rules_path.read_text())
         rules = RulesDbSchema.parse_obj(rules_db_yaml)
         scanners.append(

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -2,7 +2,7 @@
 import sys
 from pathlib import Path
 from subprocess import check_call, check_output  # noqa: S404
-from typing import Any, Optional
+from typing import cast
 from urllib.parse import urljoin
 
 import typer
@@ -10,8 +10,15 @@ import yaml
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
+from boostsec.registry_validator.config import RegistryConfig
+from boostsec.registry_validator.models import (
+    NamespaceType,
+    NamespaceUnion,
+    RuleRealmNamespace,
+    ScannerNamespace,
+)
 from boostsec.registry_validator.parameters import ApiEndpoint, ApiToken, RegistryPath
-from boostsec.registry_validator.shared import RegistryConfig, Rules, RulesDbModel
+from boostsec.registry_validator.schema import RulesDbSchema, RulesSchema
 
 MUTATION = gql(
     """
@@ -37,12 +44,13 @@ def _log_error_and_exit(message: str) -> None:
     sys.exit(1)
 
 
-def find_updated_scanners(
-    scanners_path: Path, git_root: Optional[Path] = None
-) -> list[Path]:
-    """Find module.yaml files."""
+def find_updated_namespaces(registry_path: Path, folder: Path) -> set[str]:
+    """Find updated namespaces in the registry path under provider folder.
+
+    Any namespace without a rules.yaml file is ignored.
+    """
     fetch_command = ["git", "fetch", "--deepen=1", "--quiet"]
-    check_call(fetch_command, cwd=git_root)  # noqa: S603 noboost
+    check_call(fetch_command, cwd=registry_path)  # noqa: S603 noboost
     diff_command = [
         "git",
         "--no-pager",
@@ -53,16 +61,127 @@ def find_updated_scanners(
         "AM",
         "HEAD~1",
         "--",
-        str(scanners_path),
+        str(folder),
     ]
-    diff_output = check_output(diff_command, cwd=git_root)  # noqa: S603 noboost
+    diff_output = check_output(diff_command, cwd=registry_path)  # noqa: S603 noboost
     diff_output_list = diff_output.decode("utf-8").splitlines()
+    paths = [
+        (registry_path / diff).parent
+        for diff in diff_output_list
+        if diff.endswith("yaml")
+    ]
+    return {str(path.relative_to(folder)) for path in paths if has_rules_yaml(path)}
 
-    modules_dic = {}
-    for path in [i for i in diff_output_list if i.endswith("yaml")]:
-        module_path = (git_root or Path(".")) / Path(path).parent
-        modules_dic[str(module_path)] = module_path
-    return [i for i in modules_dic.values() if has_rules_yaml(i)]
+
+def load_scanners(scanners_path: Path, updated_ns: set[str]) -> list[ScannerNamespace]:
+    """Load and parse all scanners under the provided path.
+
+    Any scanner using the `default` namespace will be renamed
+    to `boostsecurityio/native-scanner`.
+    """
+    scanners = []
+    for module_path in scanners_path.rglob("module.yaml"):
+        module_yaml = yaml.safe_load(module_path.read_text())
+        namespace = module_yaml["namespace"]
+        if namespace == "default":  # Support legacy default scanner name
+            namespace = "boostsecurityio/native-scanner"
+        driver = module_yaml["name"]
+        rules_path = module_path.parent / "rules.yaml"
+        rules_db_yaml = yaml.safe_load(rules_path.read_text())
+        rules = RulesDbSchema.parse_obj(rules_db_yaml)
+        scanners.append(
+            ScannerNamespace(
+                namespace=namespace,
+                driver=driver,
+                imports=rules.imports or [],
+                rules=rules.rules or {},
+                default=rules.default,
+                updated=namespace in updated_ns,
+            )
+        )
+
+    return scanners
+
+
+def load_rules_realm(
+    rules_realm_path: Path, updated_ns: set[str]
+) -> list[RuleRealmNamespace]:
+    """Load and parse all rules realm under the provided path."""
+    rules_realm = []
+    for realm_path in rules_realm_path.rglob("rules.yaml"):
+        rules_db_yaml = yaml.safe_load(realm_path.read_text())
+        rules = RulesDbSchema.parse_obj(rules_db_yaml)
+        namespace = str(realm_path.relative_to(rules_realm_path).parent)
+        rules_realm.append(
+            RuleRealmNamespace(
+                namespace=namespace,
+                rules=rules.rules or {},
+                imports=rules.imports or [],
+                default=rules.default,
+                updated=namespace in updated_ns,
+            )
+        )
+
+    return rules_realm
+
+
+def make_namespace_cache(
+    scanners: list[ScannerNamespace], rules_realm: list[RuleRealmNamespace]
+) -> dict[str, NamespaceUnion]:
+    """Create a map from scanners & rules realm with their namespace as key."""
+    return {scanner.namespace: scanner for scanner in scanners} | {
+        realm.namespace: realm for realm in rules_realm
+    }
+
+
+def rollup(
+    node: NamespaceUnion, namespace_cache: dict[str, NamespaceUnion]
+) -> NamespaceUnion:
+    """Rollup the rules, default & updated from the node imports."""
+    rules: RulesSchema = {}
+    default = None
+    updated = node.updated
+
+    for imported in node.imports:
+        imported_ns = namespace_cache[imported]
+        imported_ns = rollup(imported_ns, namespace_cache)
+        rules.update(imported_ns.rules)
+        default = imported_ns.default or default
+        updated = imported_ns.updated or updated
+
+    rules.update(node.rules)
+    default = node.default or default
+
+    if node.namespace_type == NamespaceType.Scanner:
+        return ScannerNamespace(
+            **node.dict(exclude={"rules", "default", "updated"}),
+            rules=rules,
+            default=default,
+            updated=updated,
+        )
+    else:
+        return RuleRealmNamespace(
+            **node.dict(exclude={"rules", "default", "updated"}),
+            rules=rules,
+            default=default,
+            updated=updated,
+        )
+
+
+def get_updated_scanners(
+    scanners: list[ScannerNamespace], namespace_cache: dict[str, NamespaceUnion]
+) -> list[ScannerNamespace]:
+    """Return the list of updated scanners.
+
+    A scanner is considered updated if either itself was updated or if any
+    of its imports was updated.
+    """
+    rollup_scanners = cast(
+        list[ScannerNamespace],
+        [rollup(scanner, namespace_cache) for scanner in scanners],
+    )
+
+    return [scanner for scanner in rollup_scanners if scanner.updated]
 
 
 def _get_header(api_token: str) -> dict[str, str]:
@@ -71,73 +190,6 @@ def _get_header(api_token: str) -> dict[str, str]:
         "Authorization": f"ApiKey {api_token}",
         "Content-Type": "application/json",
     }
-
-
-def _get_variables(
-    namespace: str, driver: str, rules: Rules, default_rule: Optional[str] = None
-) -> dict[str, Any]:
-    """Get the variables."""
-    variables = {
-        "rules": {
-            "namespace": namespace,
-            "defaultRule": default_rule,
-            "ruleInputs": [
-                {
-                    "categories": rule.categories,
-                    "description": rule.description,
-                    "driver": driver,
-                    "group": rule.group,
-                    "name": rule.name,
-                    "prettyName": rule.pretty_name,
-                    "ref": rule.ref,
-                }
-                for rule in rules.values()
-            ],
-        },
-    }
-    return variables
-
-
-def _get_namespace_and_driver(module: Path) -> tuple[str, str]:
-    """Get the namespace and driver."""
-    module_path = module / "module.yaml"
-    module_yaml = yaml.safe_load(module_path.read_text())
-    namespace = module_yaml["namespace"]
-    driver = module_yaml["name"]
-    return namespace, driver
-
-
-def _get_rules_and_default(
-    namespace: str, config: RegistryConfig
-) -> tuple[Rules, Optional[str]]:
-    """Get the rules and default rule if applicable."""
-    if namespace == "default":
-        namespace = "boostsecurityio/native-scanner"
-
-    scanners_path = config.scanners_path / namespace / "rules.yaml"
-    rules_realm_path = config.rules_realm_path / namespace / "rules.yaml"
-    if scanners_path.exists():
-        rules_db_yaml = yaml.safe_load(scanners_path.read_text())
-    else:
-        rules_db_yaml = yaml.safe_load(rules_realm_path.read_text())
-
-    rules_db = RulesDbModel.parse_obj(rules_db_yaml)
-    rules: Rules = {}
-    default_rule = None
-    if imports := rules_db.imports:
-        for ns in imports:
-            import_rules, imported_default = _get_rules_and_default(ns, config)
-            rules.update(import_rules)
-            default_rule = imported_default or default_rule
-
-    if module_rules := rules_db.rules:
-        rules.update(module_rules)
-
-    if default := rules_db.default:
-        rules.update(default)
-        default_rule = next(iter(default.keys()))
-
-    return rules, default_rule
 
 
 def has_rules_yaml(module: Path) -> bool:
@@ -158,28 +210,49 @@ def _get_gql_session(api_endpoint: str, header: dict[str, str]) -> Client:
 
 
 def upload_rules_db(
-    module: Path, api_endpoint: str, api_token: str, config: RegistryConfig
+    scanner: ScannerNamespace, api_endpoint: str, api_token: str
 ) -> None:
     """Upload the rules.yaml file."""
     header = _get_header(api_token)
-    namespace, driver = _get_namespace_and_driver(module)
-    rules, default_rule = _get_rules_and_default(namespace, config)
-    variables = _get_variables(namespace, driver, rules, default_rule)
     gql_session = _get_gql_session(api_endpoint, header)
 
-    print(f'Uploading rules "{namespace}" "{driver}"...')
+    print(f'Uploading rules "{scanner.namespace}" "{scanner.driver}"...')
+
+    rules = scanner.rules
+    default = None
+    if scanner.default:
+        rules.update(scanner.default)
+        default = next(iter(scanner.default.keys()))
+
     try:
         response = gql_session.execute(
             MUTATION,
-            variable_values=variables,
+            variable_values={
+                "rules": {
+                    "namespace": scanner.namespace,
+                    "defaultRule": default,
+                    "ruleInputs": [
+                        {
+                            "categories": rule.categories,
+                            "description": rule.description,
+                            "driver": scanner.driver,
+                            "group": rule.group,
+                            "name": rule.name,
+                            "prettyName": rule.pretty_name,
+                            "ref": rule.ref,
+                        }
+                        for rule in rules.values()
+                    ],
+                },
+            },
         )
     except Exception as e:  # noqa: WPS440
         _log_error_and_exit(f"Failed to upload rules: {e}.")
-
-    if response["setRules"]["__typename"] != "RuleSuccessSchema":
-        _log_error_and_exit(
-            f"Unable to upload rules-db: {response['setRules']['errorMessage']}"
-        )
+    else:
+        if response["setRules"]["__typename"] != "RuleSuccessSchema":
+            _log_error_and_exit(
+                f"Unable to upload rules-db: {response['setRules']['errorMessage']}"
+            )
 
 
 @app.command()
@@ -190,12 +263,21 @@ def main(
 ) -> None:
     """Process a rule database."""
     config = RegistryConfig.from_registry(registry_path)
-    modules = find_updated_scanners(config.scanners_path)
-    if len(modules) == 0:
+    updated_scanners = find_updated_namespaces(registry_path, config.scanners_path)
+    updated_realms = find_updated_namespaces(registry_path, config.rules_realm_path)
+    updated_ns = updated_scanners | updated_realms
+
+    scanners = load_scanners(config.scanners_path, updated_ns)
+    rules_realm = load_rules_realm(config.rules_realm_path, updated_ns)
+    namespace_cache = make_namespace_cache(scanners, rules_realm)
+    scanners_to_update = get_updated_scanners(scanners, namespace_cache)
+
+    if len(scanners_to_update) == 0:
         print("No module rules to update.")
-    else:
-        for module in modules:
-            upload_rules_db(module, api_endpoint, api_token, config)
+        return None
+
+    for scanner in get_updated_scanners(scanners, namespace_cache):
+        upload_rules_db(scanner, api_endpoint, api_token)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/boostsec/registry_validator/validate_namespaces.py
+++ b/boostsec/registry_validator/validate_namespaces.py
@@ -7,8 +7,8 @@ import yaml
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
+from boostsec.registry_validator.config import RegistryConfig
 from boostsec.registry_validator.parameters import RegistryPath
-from boostsec.registry_validator.shared import RegistryConfig
 
 MODULE_SCHEMA = """
 type: object

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -7,8 +7,9 @@ import typer
 import yaml
 from pydantic import BaseModel, ValidationError
 
+from boostsec.registry_validator.config import RegistryConfig
 from boostsec.registry_validator.parameters import RegistryPath
-from boostsec.registry_validator.shared import RegistryConfig, RulesDbModel
+from boostsec.registry_validator.schema import RulesDbSchema
 
 
 class RulesDbPath(BaseModel):
@@ -67,10 +68,10 @@ def _format_validation_error(e: dict[str, Any]) -> str:
         return f"{loc}: {msg}"
 
 
-def validate_rules_db(rules_db: Dict[str, Any]) -> RulesDbModel:
+def validate_rules_db(rules_db: Dict[str, Any]) -> RulesDbSchema:
     """Validate rule is valid."""
     try:
-        rule = RulesDbModel.parse_obj(rules_db)
+        rule = RulesDbSchema.parse_obj(rules_db)
     except ValidationError as e:
         _log_error_and_exit(
             "Rules db is invalid: "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Conftest."""
+import pytest
+from typer.testing import CliRunner
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    """Return a CliRunner."""
+    return CliRunner()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+"""Conftest."""
+from pathlib import Path
+from subprocess import check_call  # noqa: S404
+from typing import Callable
+
+import pytest
+
+
+@pytest.fixture()
+def registry_path(tmp_path: Path) -> Path:
+    """Return a temporary registry directory."""
+    registry = tmp_path / "registry"
+    registry.mkdir(parents=True)
+
+    check_call(["git", "init"], cwd=registry)  # noqa: S603 S607
+    check_call(  # noqa: S603 S607
+        ["git", "commit", "--allow-empty", "-m", "first commit"], cwd=registry
+    )
+
+    return registry
+
+
+@pytest.fixture()
+def commit_changes(registry_path: Path) -> Callable[[], None]:
+    """Commit all changes in the git_root repo."""
+
+    def commit() -> None:
+        check_call(["git", "add", "-A"], cwd=registry_path)  # noqa: S603 S607
+        check_call(  # noqa: S603 S607
+            ["git", "commit", "--allow-empty", "-am", "commit"], cwd=registry_path
+        )
+
+    return commit

--- a/tests/integration/samples/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
+++ b/tests/integration/samples/rules-realm/boostsecurityio/mitre-cwe/rules.yaml
@@ -1,0 +1,32 @@
+rules:
+  CWE-1004:
+    categories:
+    - ALL
+    - cwe-1004
+    - owasp-top-10
+    description: CWE-1004 description
+    group: top10-security-misconfiguration
+    name: CWE-1004
+    pretty_name: 'CWE-1004: Sensitive Cookie Without ''HttpOnly'' Flag'
+    ref: https://cwe.mitre.org/data/definitions/1004.html
+  CWE-1007:
+    categories:
+    - ALL
+    - boost-hardened
+    description: CWE-1007 description
+    group: top10-insecure-design
+    name: CWE-1007
+    pretty_name: 'CWE-1007: Insufficient Visual Distinction of Homoglyphs Presented
+      to User'
+    ref: https://cwe.mitre.org/data/definitions/1007.html
+
+default:
+  CWE-UNKNOWN:
+    categories:
+      - ALL
+      - boost-hardened
+    group: top10-insecure-design
+    name: CWE-UNKNOWN
+    pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule
+    description: The original rule could not be map to a CWE rule
+    ref: https://cwe.mitre.org/

--- a/tests/integration/samples/scanners/boostsecurityio/simple-scanner/module.yaml
+++ b/tests/integration/samples/scanners/boostsecurityio/simple-scanner/module.yaml
@@ -1,0 +1,10 @@
+api_version: 1.0
+
+id: simple-scanner
+name: Simple Scanner
+namespace: boostsecurityio/simple-scanner
+
+config:
+  support_diff_scan: true
+  require_full_repo: false
+

--- a/tests/integration/samples/scanners/boostsecurityio/simple-scanner/rules.yaml
+++ b/tests/integration/samples/scanners/boostsecurityio/simple-scanner/rules.yaml
@@ -1,0 +1,19 @@
+rules:
+  my-rule-1:
+    categories:
+      - ALL
+      - category-1
+    description: Lorem Ipsum
+    group: Test group 1
+    name: my-rule-1
+    pretty_name: My rule 1
+    ref: "http://my.link.com"
+  my-rule-2:
+    categories:
+      - ALL
+      - category-2
+    description: Lorem Ipsum
+    group: Test group 2
+    name: my-rule-2
+    pretty_name: My rule 2
+    ref: "http://my.link.com"

--- a/tests/integration/samples/scanners/others/missing-rules/module.yaml
+++ b/tests/integration/samples/scanners/others/missing-rules/module.yaml
@@ -1,0 +1,11 @@
+
+api_version: 1.0
+
+id: missing-rules
+name: Missing Rules
+namespace: others/missing-rules
+
+config:
+  support_diff_scan: true
+  require_full_repo: false
+

--- a/tests/integration/samples/scanners/others/only-import/module.yaml
+++ b/tests/integration/samples/scanners/others/only-import/module.yaml
@@ -1,0 +1,10 @@
+api_version: 1.0
+
+id: only-import
+name: Only Import
+namespace: others/only-import
+
+config:
+  support_diff_scan: true
+  require_full_repo: false
+

--- a/tests/integration/samples/scanners/others/only-import/rules.yaml
+++ b/tests/integration/samples/scanners/others/only-import/rules.yaml
@@ -1,0 +1,3 @@
+import:
+  - boostsecurityio/mitre-cwe
+  - boostsecurityio/simple-scanner

--- a/tests/integration/samples/scanners/others/overload/module.yaml
+++ b/tests/integration/samples/scanners/others/overload/module.yaml
@@ -1,0 +1,10 @@
+api_version: 1.0
+
+id: overload
+name: Overload
+namespace: others/overload
+
+config:
+  support_diff_scan: true
+  require_full_repo: false
+

--- a/tests/integration/samples/scanners/others/overload/rules.yaml
+++ b/tests/integration/samples/scanners/others/overload/rules.yaml
@@ -1,0 +1,22 @@
+import:
+  - boostsecurityio/mitre-cwe
+
+rules:
+  CWE-1004:
+    categories:
+    - ALL
+    description: Overload
+    group: top10-security-misconfiguration
+    name: CWE-1004
+    pretty_name: 'CWE-1004: Overload'
+    ref: https://cwe.mitre.org/data/definitions/1004.html
+  
+default:
+  CWE-OVERLOAD:
+    categories:
+      - ALL
+    group: top10-insecure-design
+    name: CWE-OVERLOAD
+    pretty_name: CWE-OVERLOAD - Overload
+    description: Overload
+    ref: https://cwe.mitre.org/

--- a/tests/integration/samples/scanners/others/with-placeholder/module.yaml
+++ b/tests/integration/samples/scanners/others/with-placeholder/module.yaml
@@ -1,0 +1,10 @@
+api_version: 1.0
+
+id: with-placeholder
+name: With Placeholder
+namespace: others/with-placeholder
+
+config:
+  support_diff_scan: true
+  require_full_repo: false
+

--- a/tests/integration/samples/scanners/others/with-placeholder/rules.yaml
+++ b/tests/integration/samples/scanners/others/with-placeholder/rules.yaml
@@ -1,0 +1,19 @@
+rules:
+  my-rule-1:
+    categories:
+      - ALL
+      - category-1
+    description: Lorem Ipsum
+    group: Test group 1
+    name: my-rule-1
+    pretty_name: My rule 1
+    ref: "{BOOSTSEC_DOC_BASE_URL}/a/b/c"
+  my-rule-2:
+    categories:
+      - ALL
+      - category-2
+    description: Lorem Ipsum
+    group: Test group 2
+    name: my-rule-2
+    pretty_name: My rule 2
+    ref: "{BOOSTSEC_DOC_BASE_URL}/d/e/f"

--- a/tests/integration/test_upload_rules_db.py
+++ b/tests/integration/test_upload_rules_db.py
@@ -1,0 +1,495 @@
+"""Upload rules integrations tests."""
+
+import shutil
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urljoin
+
+from _pytest.monkeypatch import MonkeyPatch
+from requests_mock import Mocker
+from typer.testing import CliRunner
+
+from boostsec.registry_validator.upload_rules_db import app
+
+DATADIR = Path(__file__).parent / "samples"
+
+
+def use_sample(sample: str, registry: Path) -> None:
+    """Copy the sample module to the temp registry."""
+    shutil.copytree((DATADIR / sample).absolute(), (registry / sample).absolute())
+
+
+def test_main_no_module_to_update(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """No rules should get uploaded if nothing changed."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("scanners/boostsecurityio/simple-scanner/", registry_path)
+    commit_changes()
+
+    # Commit a second time to simulate a past upload
+    # Updated rules-realm shouldn't get uploaded
+    use_sample("rules-realm/boostsecurityio/mitre-cwe", registry_path)
+    commit_changes()
+
+    result = cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 0
+    assert result.exit_code == 0
+    assert result.stdout == "No module rules to update.\n"
+
+
+def test_main_simple_scanner(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """Should parse and upload boostsecurityio/simple-scanner."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("scanners/boostsecurityio/simple-scanner/", registry_path)
+    commit_changes()
+
+    result = cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request is not None
+    request_json = requests_mock.last_request.json()
+    assert request_json["variables"] == {
+        "rules": {
+            "namespace": "boostsecurityio/simple-scanner",
+            "defaultRule": None,
+            "ruleInputs": [
+                {
+                    "categories": ["ALL", "category-1"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Simple Scanner",
+                    "group": "Test group 1",
+                    "name": "my-rule-1",
+                    "prettyName": "My rule 1",
+                    "ref": "http://my.link.com",
+                },
+                {
+                    "categories": ["ALL", "category-2"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Simple Scanner",
+                    "group": "Test group 2",
+                    "name": "my-rule-2",
+                    "prettyName": "My rule 2",
+                    "ref": "http://my.link.com",
+                },
+            ],
+        }
+    }
+
+    assert result.exit_code == 0
+    assert (
+        result.stdout
+        == 'Uploading rules "boostsecurityio/simple-scanner" "Simple Scanner"...\n'
+    )
+
+
+def test_main_only_import(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """Test importing rules & default."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("scanners/boostsecurityio/simple-scanner/", registry_path)
+    use_sample("rules-realm/boostsecurityio/mitre-cwe", registry_path)
+    commit_changes()
+
+    use_sample("scanners/others/only-import", registry_path)
+    commit_changes()
+
+    cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request is not None
+    request_json = requests_mock.last_request.json()
+    assert request_json["variables"] == {
+        "rules": {
+            "namespace": "others/only-import",
+            "defaultRule": "CWE-UNKNOWN",
+            "ruleInputs": [
+                {
+                    "categories": ["ALL", "cwe-1004", "owasp-top-10"],
+                    "description": "CWE-1004 description",
+                    "driver": "Only Import",
+                    "group": "top10-security-misconfiguration",
+                    "name": "CWE-1004",
+                    "prettyName": "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag",
+                    "ref": "https://cwe.mitre.org/data/definitions/1004.html",
+                },
+                {
+                    "categories": ["ALL", "boost-hardened"],
+                    "description": "CWE-1007 description",
+                    "driver": "Only Import",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-1007",
+                    "prettyName": (
+                        "CWE-1007: Insufficient Visual Distinction of "
+                        "Homoglyphs Presented to User"
+                    ),
+                    "ref": "https://cwe.mitre.org/data/definitions/1007.html",
+                },
+                {
+                    "categories": ["ALL", "category-1"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Only Import",
+                    "group": "Test group 1",
+                    "name": "my-rule-1",
+                    "prettyName": "My rule 1",
+                    "ref": "http://my.link.com",
+                },
+                {
+                    "categories": ["ALL", "category-2"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Only Import",
+                    "group": "Test group 2",
+                    "name": "my-rule-2",
+                    "prettyName": "My rule 2",
+                    "ref": "http://my.link.com",
+                },
+                {
+                    "categories": ["ALL", "boost-hardened"],
+                    "description": "The original rule could not be map to a CWE rule",
+                    "driver": "Only Import",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-UNKNOWN",
+                    "prettyName": (
+                        "CWE-UNKNOWN - Original rule did not map to a known CWE rule"
+                    ),
+                    "ref": "https://cwe.mitre.org/",
+                },
+            ],
+        }
+    }
+
+
+def test_main_rule_update_trigger_upload(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """Test updating an imported rule-realm should update module using it."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("scanners/boostsecurityio/simple-scanner/", registry_path)
+    use_sample("scanners/others/only-import", registry_path)
+    commit_changes()
+
+    use_sample("rules-realm/boostsecurityio/mitre-cwe", registry_path)
+    commit_changes()
+
+    cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request is not None
+    request_json = requests_mock.last_request.json()
+    assert request_json["variables"] == {
+        "rules": {
+            "namespace": "others/only-import",
+            "defaultRule": "CWE-UNKNOWN",
+            "ruleInputs": [
+                {
+                    "categories": ["ALL", "cwe-1004", "owasp-top-10"],
+                    "description": "CWE-1004 description",
+                    "driver": "Only Import",
+                    "group": "top10-security-misconfiguration",
+                    "name": "CWE-1004",
+                    "prettyName": "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag",
+                    "ref": "https://cwe.mitre.org/data/definitions/1004.html",
+                },
+                {
+                    "categories": ["ALL", "boost-hardened"],
+                    "description": "CWE-1007 description",
+                    "driver": "Only Import",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-1007",
+                    "prettyName": (
+                        "CWE-1007: Insufficient Visual Distinction of "
+                        "Homoglyphs Presented to User"
+                    ),
+                    "ref": "https://cwe.mitre.org/data/definitions/1007.html",
+                },
+                {
+                    "categories": ["ALL", "category-1"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Only Import",
+                    "group": "Test group 1",
+                    "name": "my-rule-1",
+                    "prettyName": "My rule 1",
+                    "ref": "http://my.link.com",
+                },
+                {
+                    "categories": ["ALL", "category-2"],
+                    "description": "Lorem Ipsum",
+                    "driver": "Only Import",
+                    "group": "Test group 2",
+                    "name": "my-rule-2",
+                    "prettyName": "My rule 2",
+                    "ref": "http://my.link.com",
+                },
+                {
+                    "categories": ["ALL", "boost-hardened"],
+                    "description": "The original rule could not be map to a CWE rule",
+                    "driver": "Only Import",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-UNKNOWN",
+                    "prettyName": (
+                        "CWE-UNKNOWN - Original rule did not map to a known CWE rule"
+                    ),
+                    "ref": "https://cwe.mitre.org/",
+                },
+            ],
+        }
+    }
+
+
+def test_main_rule_import_overload(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """Test rules importing with rules overloading."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("rules-realm/boostsecurityio/mitre-cwe", registry_path)
+    use_sample("scanners/others/overload", registry_path)
+    commit_changes()
+
+    cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request is not None
+    request_json = requests_mock.last_request.json()
+    assert request_json["variables"] == {
+        "rules": {
+            "namespace": "others/overload",
+            "defaultRule": "CWE-OVERLOAD",
+            "ruleInputs": [
+                {
+                    "categories": ["ALL"],
+                    "description": "Overload",
+                    "driver": "Overload",
+                    "group": "top10-security-misconfiguration",
+                    "name": "CWE-1004",
+                    "prettyName": "CWE-1004: Overload",
+                    "ref": "https://cwe.mitre.org/data/definitions/1004.html",
+                },
+                {
+                    "categories": ["ALL", "boost-hardened"],
+                    "description": "CWE-1007 description",
+                    "driver": "Overload",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-1007",
+                    "prettyName": (
+                        "CWE-1007: Insufficient Visual Distinction "
+                        "of Homoglyphs Presented to User"
+                    ),
+                    "ref": "https://cwe.mitre.org/data/definitions/1007.html",
+                },
+                {
+                    "categories": ["ALL"],
+                    "description": "Overload",
+                    "driver": "Overload",
+                    "group": "top10-insecure-design",
+                    "name": "CWE-OVERLOAD",
+                    "prettyName": "CWE-OVERLOAD - Overload",
+                    "ref": "https://cwe.mitre.org/",
+                },
+            ],
+        }
+    }
+
+
+def test_main_with_placeholder(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test rules with env placeholder."""
+    doc_url = "https://my_doc_url"
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    env_var_name = "BOOSTSEC_DOC_BASE_URL"
+    monkeypatch.setenv(env_var_name, doc_url)
+
+    use_sample("scanners/others/with-placeholder", registry_path)
+    commit_changes()
+
+    cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request is not None
+    request_json = requests_mock.last_request.json()
+    assert request_json["variables"] == {
+        "rules": {
+            "namespace": "others/with-placeholder",
+            "defaultRule": None,
+            "ruleInputs": [
+                {
+                    "categories": ["ALL", "category-1"],
+                    "description": "Lorem Ipsum",
+                    "driver": "With Placeholder",
+                    "group": "Test group 1",
+                    "name": "my-rule-1",
+                    "prettyName": "My rule 1",
+                    "ref": f"{doc_url}/a/b/c",
+                },
+                {
+                    "categories": ["ALL", "category-2"],
+                    "description": "Lorem Ipsum",
+                    "driver": "With Placeholder",
+                    "group": "Test group 2",
+                    "name": "my-rule-2",
+                    "prettyName": "My rule 2",
+                    "ref": f"{doc_url}/d/e/f",
+                },
+            ],
+        },
+    }
+
+
+def test_main_module_missing_rules(
+    cli_runner: CliRunner,
+    registry_path: Path,
+    requests_mock: Mocker,
+    commit_changes: Callable[[], None],
+) -> None:
+    """Should warn and exit if a module is missing a rules db."""
+    url = "https://my_endpoint/"
+    requests_mock.post(
+        urljoin(url, "/rules-management/graphql"),
+        json={
+            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
+        },
+    )
+
+    use_sample("scanners/others/missing-rules", registry_path)
+    commit_changes()
+
+    result = cli_runner.invoke(
+        app,
+        [
+            "--api-endpoint",
+            url,
+            "--api-token",
+            "my-token",
+            "--registry-path",
+            str(registry_path),
+        ],
+    )
+
+    assert requests_mock.call_count == 0
+    assert result.exit_code == 1
+    assert "WARNING: rules.yaml not found in " in result.stdout

--- a/tests/integration/test_upload_rules_db.py
+++ b/tests/integration/test_upload_rules_db.py
@@ -491,5 +491,5 @@ def test_main_module_missing_rules(
     )
 
     assert requests_mock.call_count == 0
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "WARNING: rules.yaml not found in " in result.stdout

--- a/tests/unit/scanner/conftest.py
+++ b/tests/unit/scanner/conftest.py
@@ -2,9 +2,8 @@
 from pathlib import Path
 
 import pytest
-from typer.testing import CliRunner
 
-from boostsec.registry_validator.shared import RegistryConfig
+from boostsec.registry_validator.config import RegistryConfig
 
 
 @pytest.fixture()
@@ -40,9 +39,3 @@ def registry_config(scanners_path: Path, rules_realm_path: Path) -> RegistryConf
     return RegistryConfig(
         scanners_path=scanners_path, rules_realm_path=rules_realm_path
     )
-
-
-@pytest.fixture()
-def cli_runner() -> CliRunner:
-    """Return a CliRunner."""
-    return CliRunner()

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -2,27 +2,31 @@
 from pathlib import Path
 from subprocess import check_call  # noqa: S404
 from typing import Any
-from unittest.mock import Mock, patch
 from urllib.parse import urljoin
 
 import pytest
 import yaml
-from _pytest.monkeypatch import MonkeyPatch
+from pydantic import AnyHttpUrl
 from requests_mock import Mocker
-from typer.testing import CliRunner
 
-from boostsec.registry_validator.shared import RegistryConfig
-from boostsec.registry_validator.upload_rules_db import (
-    app,
-    find_updated_scanners,
+from boostsec.registry_validator.models import RuleRealmNamespace, ScannerNamespace
+from boostsec.registry_validator.testing.factories import (
+    RuleRealmNamespaceFactory,
+    RuleSchemaFactory,
+    RulesDbSchemaFactory,
+    ScannerNamespaceFactory,
+)
+from boostsec.registry_validator.upload_rules_db import (  # find_updated_scanners,
+    find_updated_namespaces,
+    load_rules_realm,
+    load_scanners,
+    make_namespace_cache,
+    rollup,
     upload_rules_db,
 )
-from tests.unit.scanner.test_validate_rules_db import (
-    VALID_RULES_DB_STRING,
-    VALID_RULES_DB_STRING_WITH_DEFAULT,
-    VALID_RULES_DB_STRING_WITH_IMPORTS,
-    VALID_RULES_DB_STRING_WITH_ONLY_IMPORT,
-    VALID_RULES_DB_STRING_WITH_PLACEHOLDER,
+
+yaml.SafeDumper.add_representer(  # use to create fake rules.yaml
+    AnyHttpUrl, lambda dumper, url: dumper.represent_str(str(url))
 )
 
 
@@ -81,95 +85,147 @@ def _commit_all_changes(git_root: Path, message: str = "commit") -> None:
 
 
 @pytest.mark.parametrize(
-    "namespace",
+    ("namespace", "expected"),
     [
-        "namespace-example",
-        "default",
+        ("namespace-example", "namespace-example"),
+        ("default", "boostsecurityio/native-scanner"),
     ],
 )
-def test_upload_rules_db(
-    registry_config: RegistryConfig, requests_mock: Mocker, namespace: str
-) -> None:
-    """Test upload_rules_db."""
-    url = "https://my_endpoint/"
-    test_token = "my-random-key"  # noqa: S105
+def test_get_scanners_rules(scanners_path: Path, namespace: str, expected: str) -> None:
+    """Should load all and convert every scanners.
 
-    def has_auth_token(request: Any) -> bool:
-        assert request.headers["Authorization"] == f"ApiKey {test_token}"
-        return True
-
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        additional_matcher=has_auth_token,
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
+    For backward compatibility, any namespace named default should be renamed
+    to boostsecurityio/native-scanner.
+    """
+    rules = {
+        "my-rule-1": RuleSchemaFactory.build(name="my-rule-1"),
+        "my-rule-2": RuleSchemaFactory.build(name="my-rule-2"),
+    }
+    rules_db = RulesDbSchemaFactory.build(rules=rules, imports=["imported/ns"])
 
     _create_module_and_rules(
-        registry_config.scanners_path,
-        VALID_RULES_DB_STRING,
-        "boostsecurityio/native-scanner",  # Support legacy default scanner name
-    )
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING, namespace
+        scanners_path,
+        yaml.safe_dump(rules_db.dict()),
+        namespace,
     )
 
-    upload_rules_db(module_path.parent, url, test_token, registry_config)
+    result = load_scanners(scanners_path, {expected})
+    assert result == [
+        ScannerNamespace(
+            namespace=expected,
+            driver="Example Scanner",
+            rules=rules,
+            imports=["imported/ns"],
+            updated=True,
+        ),
+    ]
 
-    assert requests_mock.call_count == 1
-    assert requests_mock.last_request is not None
-    assert requests_mock.last_request.json() == {
-        "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
-        "variables": {
-            "rules": {
-                "namespace": namespace,
-                "defaultRule": None,
-                "ruleInputs": [
-                    {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": "http://my.link.com",
-                    },
-                ],
-            }
-        },
+
+def test_load_rules_realm(rules_realm_path: Path) -> None:
+    """Should load all and convert every rules-realm."""
+    ns = "boostsecurityio/mitre-cwe"
+    rules = {
+        "my-rule-1": RuleSchemaFactory.build(name="my-rule-1"),
+        "my-rule-2": RuleSchemaFactory.build(name="my-rule-2"),
+    }
+    rules_db = RulesDbSchemaFactory.build(rules=rules, imports=["imported/ns"])
+
+    _create_rules_realm(rules_realm_path, yaml.safe_dump(rules_db.dict()), ns)
+
+    result = load_rules_realm(rules_realm_path, {ns})
+    assert result == [
+        RuleRealmNamespace(
+            namespace=ns, rules=rules, imports=["imported/ns"], updated=True
+        )
+    ]
+
+
+def test_make_namespace_cache() -> None:
+    """Test building namespace cache from scanners & realms ns.
+
+    There should be an entry for every scanners & rules with their name as key.
+    """
+    scanners = ScannerNamespaceFactory.batch(2)
+    realms = RuleRealmNamespaceFactory.batch(2)
+    cache = make_namespace_cache(scanners, realms)
+
+    for scanner in scanners:
+        assert cache[scanner.namespace] == scanner
+
+    for realm in realms:
+        assert cache[realm.namespace] == realm
+
+
+def test_rollup() -> None:
+    """Test that rules & default get loaded correctly from imports."""
+    rules_1 = {
+        "r1": RuleSchemaFactory.build(name="r1"),
+        "r2": RuleSchemaFactory.build(name="r2"),
+    }
+    rules_2 = {
+        "r3": RuleSchemaFactory.build(name="r3"),
+        "r4": RuleSchemaFactory.build(name="r4"),
     }
 
+    default = {"default": RuleSchemaFactory.build(name="default")}
 
-def test_upload_rules_db_with_placeholder(
-    requests_mock: Mocker, registry_config: RegistryConfig, monkeypatch: MonkeyPatch
-) -> None:
+    n1 = ScannerNamespaceFactory.build(namespace="r1", rules=rules_1)
+    n2 = RuleRealmNamespaceFactory.build(
+        namespace="r2", rules=rules_2, default=default, imports=["r1"], updated=True
+    )
+    n3 = ScannerNamespaceFactory.build(namespace="r3", imports=["r1", "r2"])
+
+    cache = make_namespace_cache([n1, n3], [n2])
+
+    n1_res = rollup(n1, cache)
+    assert n1_res.rules == rules_1
+    assert n1_res.default is None
+    assert not n1_res.updated
+
+    n2_res = rollup(n2, cache)
+    assert n2_res.rules == rules_2 | rules_1
+    assert n2_res.default == default
+    assert n2_res.updated
+
+    n3_res = rollup(n3, cache)
+    assert n3_res.rules == rules_2 | rules_1
+    assert n3_res.default == default
+    assert n3_res.updated
+
+
+@pytest.mark.parametrize("with_default", [True, False])
+def test_upload_rules_db(requests_mock: Mocker, with_default: bool) -> None:
     """Test upload_rules_db."""
-    doc_url = "https://my_doc_url"
-    url = "https://my_endpoint"
-    env_var_name = "BOOSTSEC_DOC_BASE_URL"
-    monkeypatch.setenv(env_var_name, doc_url)
+    url = "https://my_endpoint/"
+    test_token = "my-random-key"  # noqa: S105
+    rules = RuleSchemaFactory.batch(2)
+    default = None
+    if with_default:
+        default = RuleSchemaFactory.build(name="default-rule")
+
+    scanner = ScannerNamespaceFactory.build(
+        driver="Example Scanner",
+        rules={rule.name: rule for rule in rules},
+        default={default.name: default} if default else None,
+    )
+
+    def has_auth_token(request: Any) -> bool:
+        assert request.headers["Authorization"] == f"ApiKey {test_token}"
+        return True
+
     requests_mock.post(
         urljoin(url, "/rules-management/graphql"),
+        additional_matcher=has_auth_token,
         json={
             "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
         },
     )
-    namespace = "namespace-example"
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING_WITH_PLACEHOLDER, namespace
-    )
 
-    upload_rules_db(module_path.parent, url, "my-token", registry_config)
+    upload_rules_db(scanner, url, test_token)
+
+    if with_default:
+        assert default
+        rules.append(default)
 
     assert requests_mock.call_count == 1
     assert requests_mock.last_request is not None
@@ -177,381 +233,19 @@ def test_upload_rules_db_with_placeholder(
         "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
         "variables": {
             "rules": {
-                "namespace": "namespace-example",
-                "defaultRule": None,
+                "namespace": scanner.namespace,
+                "defaultRule": default.name if default else None,
                 "ruleInputs": [
                     {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": f"{doc_url}/a/b/c",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": f"{doc_url}/d/e/f",
-                    },
-                ],
-            }
-        },
-    }
-
-
-@pytest.mark.parametrize("from_realm", [True, False])
-def test_upload_rules_db_with_imports(
-    requests_mock: Mocker, registry_config: RegistryConfig, from_realm: bool
-) -> None:
-    """Test upload_rules_db correctly handles import statement.
-
-    Imported rules should be added to the importer namespace. Rules defined
-    in the importer should overwrite rules defined in the imports. Same goes
-    for multiple imported rules, the last caller take priority.
-    """
-    url = "https://my_endpoint"
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path,
-        """
-        import:
-          - namespace/module-a
-          - namespace/module-c
-
-        rules:
-          my-rule-1:
-            categories:
-              - ALL
-              - category-1
-            description: Defined in B
-            group: Test group 1
-            name: my-rule-1
-            pretty_name: My rule 1
-            ref: "http://my.link.com"
-        """,
-        "namespace/module-b",
-    )
-
-    module_c = """
-            import:
-              - namespace/module-a
-            """
-
-    if from_realm:
-        _create_rules_realm(
-            registry_config.rules_realm_path,
-            module_c,
-            "namespace/module-c",
-        )
-    else:
-        _create_module_and_rules(
-            registry_config.scanners_path,
-            module_c,
-            "namespace/module-c",
-        )
-
-    module_a = """
-        rules:
-          my-rule-1:
-            categories:
-              - ALL
-              - category-1
-            description: Defined in A
-            group: Test group 1
-            name: my-rule-1
-            pretty_name: My rule 1
-            ref: "http://my.link.com"
-          my-rule-2:
-            categories:
-              - ALL
-              - category-2
-            description: Defined in A
-            group: Test group 2
-            name: my-rule-2
-            pretty_name: My rule 2
-            ref: "http://my.link.com"
-        """
-
-    if from_realm:
-        _create_rules_realm(
-            registry_config.rules_realm_path,
-            module_a,
-            "namespace/module-a",
-        )
-    else:
-        _create_module_and_rules(
-            registry_config.scanners_path,
-            module_a,
-            "namespace/module-a",
-        )
-
-    upload_rules_db(module_path.parent, url, "my-token", registry_config)
-
-    assert requests_mock.call_count == 1
-    assert requests_mock.last_request is not None
-    assert requests_mock.last_request.json() == {
-        "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
-        "variables": {
-            "rules": {
-                "namespace": "namespace/module-b",
-                "defaultRule": None,
-                "ruleInputs": [
-                    {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Defined in B",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Defined in A",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": "http://my.link.com",
-                    },
-                ],
-            }
-        },
-    }
-
-
-def test_upload_rules_db_with_default(
-    registry_config: RegistryConfig, requests_mock: Mocker
-) -> None:
-    """Test upload_rules_db with a default rule."""
-    url = "https://my_endpoint/"
-    test_token = "my-random-key"  # noqa: S105
-
-    def has_auth_token(request: Any) -> bool:
-        assert request.headers["Authorization"] == f"ApiKey {test_token}"
-        return True
-
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        additional_matcher=has_auth_token,
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-
-    namespace = "namespace-example"
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING_WITH_DEFAULT, namespace
-    )
-
-    upload_rules_db(
-        module_path.parent,
-        url,
-        test_token,
-        registry_config,
-    )
-
-    assert requests_mock.call_count == 1
-    assert requests_mock.last_request is not None
-    req_json = requests_mock.last_request.json()
-    assert req_json == {
-        "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
-        "variables": {
-            "rules": {
-                "namespace": "namespace-example",
-                "defaultRule": "my-rule-2",
-                "ruleInputs": [
-                    {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": "http://my.link.com",
-                    },
-                ],
-            }
-        },
-    }
-
-
-def test_upload_rules_db_with_imported_default(
-    registry_config: RegistryConfig, requests_mock: Mocker
-) -> None:
-    """Should include any imported default rule."""
-    url = "https://my_endpoint/"
-    test_token = "my-random-key"  # noqa: S105
-
-    def has_auth_token(request: Any) -> bool:
-        assert request.headers["Authorization"] == f"ApiKey {test_token}"
-        return True
-
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        additional_matcher=has_auth_token,
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-
-    _create_rules_realm(
-        registry_config.rules_realm_path,
-        VALID_RULES_DB_STRING_WITH_DEFAULT,
-        "namespace/module-a",
-    )
-
-    namespace = "namespace-example"
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING_WITH_ONLY_IMPORT, namespace
-    )
-
-    upload_rules_db(
-        module_path.parent,
-        url,
-        test_token,
-        registry_config,
-    )
-
-    assert requests_mock.call_count == 1
-    assert requests_mock.last_request is not None
-    req_json = requests_mock.last_request.json()
-    assert req_json == {
-        "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
-        "variables": {
-            "rules": {
-                "namespace": "namespace-example",
-                "defaultRule": "my-rule-2",
-                "ruleInputs": [
-                    {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": "http://my.link.com",
-                    },
-                ],
-            }
-        },
-    }
-
-
-def test_upload_rules_db_imported_default_precedence(
-    registry_config: RegistryConfig, requests_mock: Mocker
-) -> None:
-    """Module default should take precedence over any imported one."""
-    url = "https://my_endpoint/"
-    test_token = "my-random-key"  # noqa: S105
-
-    def has_auth_token(request: Any) -> bool:
-        assert request.headers["Authorization"] == f"ApiKey {test_token}"
-        return True
-
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        additional_matcher=has_auth_token,
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-
-    _create_rules_realm(
-        registry_config.rules_realm_path,
-        VALID_RULES_DB_STRING_WITH_DEFAULT,
-        "namespace/module-a",
-    )
-
-    namespace = "namespace-example"
-    rules = VALID_RULES_DB_STRING_WITH_ONLY_IMPORT
-    rules += """
-default:
-  my-default:
-    categories:
-      - ALL
-    description: Lorem Ipsum
-    group: Test default
-    name: my-default
-    pretty_name: My Default
-    ref: "http://my.link.com"
-    """
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, rules, namespace
-    )
-
-    upload_rules_db(
-        module_path.parent,
-        url,
-        test_token,
-        registry_config,
-    )
-
-    assert requests_mock.call_count == 1
-    assert requests_mock.last_request is not None
-    req_json = requests_mock.last_request.json()
-    assert req_json == {
-        "query": "mutation setRules($rules: RuleInputSchemas!) {\n  setRules(namespacedRules: $rules) {\n    __typename\n    ... on RuleSuccessSchema {\n      successMessage\n    }\n    ... on RuleErrorSchema {\n      errorMessage\n    }\n  }\n}",  # noqa: E501
-        "variables": {
-            "rules": {
-                "namespace": "namespace-example",
-                "defaultRule": "my-default",
-                "ruleInputs": [
-                    {
-                        "categories": ["ALL", "category-1"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 1",
-                        "name": "my-rule-1",
-                        "prettyName": "My rule 1",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL", "category-2"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test group 2",
-                        "name": "my-rule-2",
-                        "prettyName": "My rule 2",
-                        "ref": "http://my.link.com",
-                    },
-                    {
-                        "categories": ["ALL"],
-                        "description": "Lorem Ipsum",
-                        "driver": "Example Scanner",
-                        "group": "Test default",
-                        "name": "my-default",
-                        "prettyName": "My Default",
-                        "ref": "http://my.link.com",
-                    },
+                        "categories": rule.categories,
+                        "description": rule.description,
+                        "driver": scanner.driver,
+                        "group": rule.group,
+                        "name": rule.name,
+                        "prettyName": rule.pretty_name,
+                        "ref": rule.ref,
+                    }
+                    for rule in rules
                 ],
             }
         },
@@ -559,9 +253,7 @@ default:
 
 
 def test_upload_rules_db_permission_denied(
-    capfd: pytest.CaptureFixture[str],
-    registry_config: RegistryConfig,
-    requests_mock: Mocker,
+    capfd: pytest.CaptureFixture[str], requests_mock: Mocker
 ) -> None:
     """Test upload_rules_db."""
     url = "https://my_endpoint/"
@@ -578,18 +270,13 @@ def test_upload_rules_db_permission_denied(
             ],
         },
     )
-    namespace = "namespace-example"
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING, namespace
-    )
+    scanner = ScannerNamespaceFactory.build()
     with pytest.raises(SystemExit):
-        upload_rules_db(
-            module_path.parent, "https://my_endpoint/", "my-token", registry_config
-        )
+        upload_rules_db(scanner, "https://my_endpoint/", "my-token")
     out, _ = capfd.readouterr()
     assert out == "\n".join(
         [
-            'Uploading rules "namespace-example" "Example Scanner"...',
+            f'Uploading rules "{scanner.namespace}" "{scanner.driver}"...',
             "ERROR: Failed to upload rules: {'message': 'Permission denied', 'locations': [{'line': 2, 'column': 5}], 'path': ['setRules']}.",  # noqa: E501
             "",
         ]
@@ -597,9 +284,7 @@ def test_upload_rules_db_permission_denied(
 
 
 def test_upload_rules_db_error_response(
-    capfd: pytest.CaptureFixture[str],
-    registry_config: RegistryConfig,
-    requests_mock: Mocker,
+    capfd: pytest.CaptureFixture[str], requests_mock: Mocker
 ) -> None:
     """Test upload_rules_db."""
     url = "https://my_endpoint/"
@@ -614,24 +299,21 @@ def test_upload_rules_db_error_response(
             },
         },
     )
-    namespace = "namespace-example"
-    module_path = _create_module_and_rules(
-        registry_config.scanners_path, VALID_RULES_DB_STRING, namespace
-    )
+    scanner = ScannerNamespaceFactory.build()
 
     with pytest.raises(SystemExit):
-        upload_rules_db(module_path.parent, url, "my-token", registry_config)
+        upload_rules_db(scanner, url, "my-token")
     out, _ = capfd.readouterr()
     assert out == "\n".join(
         [
-            'Uploading rules "namespace-example" "Example Scanner"...',
+            f'Uploading rules "{scanner.namespace}" "{scanner.driver}"...',
             "ERROR: Unable to upload rules-db: Error message",
             "",
         ]
     )
 
 
-def test_find_updated_scanners(registry_path: Path, scanners_path: Path) -> None:
+def test_find_updated_namespaces(registry_path: Path, scanners_path: Path) -> None:
     """Should return the list of updated modules since the last commit.
 
     Any modules updated prior should not be included.
@@ -643,17 +325,20 @@ def test_find_updated_scanners(registry_path: Path, scanners_path: Path) -> None
     (ignored_module / "rules.yaml").touch()
     _commit_all_changes(registry_path)
 
-    modules = [scanners_path / "a", scanners_path / "b"]
+    modules = [scanners_path / "domain/a", scanners_path / "domain/deep/b"]
     for module in modules:
         module.mkdir(parents=True)
         (module / "module.yaml").touch()
         (module / "rules.yaml").touch()
 
     _commit_all_changes(registry_path)
-    assert find_updated_scanners(scanners_path, git_root=registry_path) == modules
+    assert find_updated_namespaces(registry_path, scanners_path) == {
+        "domain/a",
+        "domain/deep/b",
+    }
 
 
-def test_find_updated_scanners_only_rules(
+def test_find_updated_namespaces_only_rules(
     registry_path: Path, scanners_path: Path
 ) -> None:
     """Should return the updated module even if only rules.yaml was updated."""
@@ -668,10 +353,10 @@ def test_find_updated_scanners_only_rules(
     rules.write_text("some changes")
     _commit_all_changes(registry_path)
 
-    assert find_updated_scanners(scanners_path, git_root=registry_path) == [module]
+    assert find_updated_namespaces(registry_path, scanners_path) == {"ns/test"}
 
 
-def test_find_updated_scanners_no_rules(
+def test_find_updated_namespaces_no_rules(
     registry_path: Path, scanners_path: Path
 ) -> None:
     """Should ignore module without rules db."""
@@ -681,219 +366,4 @@ def test_find_updated_scanners_no_rules(
     (module / "module.yaml").touch()
     _commit_all_changes(registry_path)
 
-    assert find_updated_scanners(scanners_path, git_root=registry_path) == []
-
-
-def test_find_updated_scanners_ignore_rules_realm(
-    registry_path: Path, scanners_path: Path, rules_realm_path: Path
-) -> None:
-    """Should only return module under the scanners path."""
-    _init_repo(registry_path)
-    rules = rules_realm_path / "ns/test"
-    rules.mkdir(parents=True)
-    (rules / "rules.yaml").touch()
-
-    module = scanners_path / "ns/test"
-    module.mkdir(parents=True)
-    (module / "module.yaml").touch()
-    (module / "rules.yaml").touch()
-    _commit_all_changes(registry_path)
-
-    assert find_updated_scanners(scanners_path, git_root=registry_path) == [module]
-
-
-@patch("boostsec.registry_validator.upload_rules_db.check_output")
-@patch("boostsec.registry_validator.upload_rules_db.check_call", Mock())
-def test_main_success(
-    mock_check_output: Any,
-    cli_runner: CliRunner,
-    registry_path: Path,
-    scanners_path: Path,
-    requests_mock: Mocker,
-) -> None:
-    """Test upload_rules_db."""
-    url = "https://my_endpoint/"
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-    namespace = "namespace-example-main"
-
-    module_path = _create_module_and_rules(
-        scanners_path, VALID_RULES_DB_STRING, namespace
-    )
-    mock_subprocess_decode = mock_check_output.return_value.decode
-    mock_subprocess_decode.return_value.splitlines.return_value = [str(module_path)]
-
-    result = cli_runner.invoke(
-        app,
-        [
-            "--api-endpoint",
-            "https://my_endpoint/",
-            "--api-token",
-            "my-token",
-            "--registry-path",
-            str(registry_path),
-        ],
-    )
-
-    assert requests_mock.call_count == 1
-    assert (
-        result.stdout
-        == 'Uploading rules "namespace-example-main" "Example Scanner"...\n'
-    )
-
-
-@patch("boostsec.registry_validator.upload_rules_db.check_output")
-@patch("boostsec.registry_validator.upload_rules_db.check_call", Mock())
-def test_main_success_warning(
-    mock_check_output: Any,
-    cli_runner: CliRunner,
-    registry_path: Path,
-    scanners_path: Path,
-    requests_mock: Mocker,
-) -> None:
-    """Test upload_rules_db."""
-    url = "https://my_endpoint/"
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-    module1 = _create_module_and_rules(
-        scanners_path, VALID_RULES_DB_STRING, "namespace-example-main"
-    )
-    module2 = _create_module_and_rules(
-        scanners_path,
-        VALID_RULES_DB_STRING,
-        "namespace-example-main2",
-        create_rules=False,
-    )
-    mock_subprocess_decode = mock_check_output.return_value.decode
-    mock_subprocess_decode.return_value.splitlines.return_value = [
-        str(module1),
-        str(module2),
-    ]
-
-    result = cli_runner.invoke(
-        app,
-        [
-            "--api-endpoint",
-            "https://my_endpoint/",
-            "--api-token",
-            "my-token",
-            "--registry-path",
-            str(registry_path),
-        ],
-    )
-
-    assert requests_mock.call_count == 1
-    assert "WARNING: rules.yaml not found in " in result.stdout
-
-
-@patch("boostsec.registry_validator.upload_rules_db.check_output")
-@patch("boostsec.registry_validator.upload_rules_db.check_call", Mock())
-def test_main_no_modules_to_update(
-    mock_check_output: Any,
-    cli_runner: CliRunner,
-    registry_path: Path,
-    requests_mock: Mocker,
-) -> None:
-    """Test upload_rules_db."""
-    mock_subprocess_decode = mock_check_output.return_value.decode
-    mock_subprocess_decode.return_value.splitlines.return_value = []
-
-    result = cli_runner.invoke(
-        app,
-        [
-            "--api-endpoint",
-            "https://my_endpoint/",
-            "--api-token",
-            "my-token",
-            "--registry-path",
-            str(registry_path),
-        ],
-    )
-
-    assert requests_mock.call_count == 0
-    assert result.stdout == "No module rules to update.\n"
-
-
-@patch("boostsec.registry_validator.upload_rules_db.check_output")
-@patch("boostsec.registry_validator.upload_rules_db.check_call", Mock())
-def test_main_only_rules_realm(
-    mock_check_output: Any,
-    cli_runner: CliRunner,
-    registry_path: Path,
-    rules_realm_path: Path,
-    requests_mock: Mocker,
-) -> None:
-    """Rules realm should not be uploaded if not imported."""
-    _create_rules_realm(rules_realm_path, VALID_RULES_DB_STRING, "ns/rules")
-
-    mock_subprocess_decode = mock_check_output.return_value.decode
-    mock_subprocess_decode.return_value.splitlines.return_value = []
-
-    result = cli_runner.invoke(
-        app,
-        [
-            "--api-endpoint",
-            "https://my_endpoint/",
-            "--api-token",
-            "my-token",
-            "--registry-path",
-            str(registry_path),
-        ],
-    )
-
-    assert requests_mock.call_count == 0
-    assert result.stdout == "No module rules to update.\n"
-
-
-@patch("boostsec.registry_validator.upload_rules_db.check_output")
-@patch("boostsec.registry_validator.upload_rules_db.check_call", Mock())
-def test_main_only_rules_realm_with_module(
-    mock_check_output: Any,
-    cli_runner: CliRunner,
-    registry_path: Path,
-    scanners_path: Path,
-    rules_realm_path: Path,
-    requests_mock: Mocker,
-) -> None:
-    """Rules realm should not be picked up, but the real module should."""
-    url = "https://my_endpoint/"
-    requests_mock.post(
-        urljoin(url, "/rules-management/graphql"),
-        json={
-            "data": {"setRules": {"__typename": "RuleSuccessSchema"}},
-        },
-    )
-
-    _create_rules_realm(rules_realm_path, VALID_RULES_DB_STRING, "namespace/module-a")
-
-    module = _create_module_and_rules(
-        scanners_path, VALID_RULES_DB_STRING_WITH_IMPORTS, "ns/test"
-    )
-
-    mock_subprocess_decode = mock_check_output.return_value.decode
-    mock_subprocess_decode.return_value.splitlines.return_value = [
-        str(module),
-    ]
-
-    result = cli_runner.invoke(
-        app,
-        [
-            "--api-endpoint",
-            "https://my_endpoint/",
-            "--api-token",
-            "my-token",
-            "--registry-path",
-            str(registry_path),
-        ],
-    )
-
-    assert requests_mock.call_count == 1
-    assert result.stdout == 'Uploading rules "ns/test" "Example Scanner"...\n'
+    assert find_updated_namespaces(registry_path, scanners_path) == set()

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -1,7 +1,7 @@
 """Test."""
 from pathlib import Path
 from subprocess import check_call  # noqa: S404
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urljoin
 
 import pytest

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 from typer.testing import CliRunner
 
-from boostsec.registry_validator.shared import RegistryConfig
+from boostsec.registry_validator.config import RegistryConfig
 from boostsec.registry_validator.validate_rules_db import (
     RulesDbPath,
     app,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,11 @@
+"""Tests for shared module."""
+from pathlib import Path
+
+from boostsec.registry_validator.config import RegistryConfig
+
+
+def test_registry_config_from_path(tmp_path: Path) -> None:
+    """Should init config from a registry base path."""
+    config = RegistryConfig.from_registry(tmp_path)
+    assert config.scanners_path == tmp_path / "scanners"
+    assert config.rules_realm_path == tmp_path / "rules-realm"


### PR DESCRIPTION
The import & updated logic was modified to handle detection of module whose dependencies were modified. The new logic is to first load all the scanners & rules-realm from the registry, marking the updated namespace, and finally resolving the rules, default rule and updated status for each scanner module.

To avoid confusion, the shared module was split into schema, config & models.

Integrations tests were also added in order to better e2e test the upload. Those tests create a temporary git repo for the registry, copies the module & rules yaml files and run cli. This setup is closer to the real use of the cli. They are not considered "module tests" since the request to the backend are still mocked.