### PR TITLE
BST-6070: Validate namespace module schema

### DIFF
--- a/boostsec/registry_validator/errors.py
+++ b/boostsec/registry_validator/errors.py
@@ -1,0 +1,15 @@
+"""CLI errors."""
+from typing import Any
+
+
+def format_validation_error(e: dict[str, Any]) -> str:
+    """Format the error message of a pydantic validation error."""
+    error_type = e["type"]
+    loc = ".".join(str(loc) for loc in e["loc"])
+    if error_type == "value_error.missing":
+        return f"{loc} is a required property"
+    elif error_type == "value_error.extra":
+        return f"Additional properties are not allowed ({loc} was unexpected)"
+    else:
+        msg = e.get("msg", "unknown error")
+        return f"{loc}: {msg}"

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -5,6 +5,23 @@ from typing import Any, Optional
 from pydantic import AnyHttpUrl, BaseModel, Field, validator
 
 
+class ModuleConfigSchema(BaseModel):
+    """Representation of a module config."""
+
+    support_diff_scan: bool
+
+
+class ModuleSchema(BaseModel):
+    """Representation of a module file content."""
+
+    api_version: int
+    id_: str = Field(..., alias="id")
+    name: str
+    namespace: str
+    config: ModuleConfigSchema
+    steps: list[Any]  # steps aren't currently validated
+
+
 class RuleSchema(BaseModel):
     """Representation of a scanner rule."""
 

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -4,7 +4,13 @@ from typing import cast
 from pydantic_factories import ModelFactory, Use
 
 from boostsec.registry_validator.models import RuleRealmNamespace, ScannerNamespace
-from boostsec.registry_validator.schema import RuleSchema, RulesDbSchema
+from boostsec.registry_validator.schema import ModuleSchema, RuleSchema, RulesDbSchema
+
+
+class ModuleSchemaFactory(ModelFactory[ModuleSchema]):
+    """Factory."""
+
+    __model__ = ModuleSchema
 
 
 class RuleSchemaFactory(ModelFactory[RuleSchema]):

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -8,6 +8,7 @@ import yaml
 from pydantic import BaseModel, ValidationError
 
 from boostsec.registry_validator.config import RegistryConfig
+from boostsec.registry_validator.errors import format_validation_error
 from boostsec.registry_validator.parameters import RegistryPath
 from boostsec.registry_validator.schema import RulesDbSchema
 
@@ -56,18 +57,6 @@ def load_yaml_file(file_path: Path) -> Any:
     return {}
 
 
-def _format_validation_error(e: dict[str, Any]) -> str:
-    error_type = e["type"]
-    loc = ".".join(str(loc) for loc in e["loc"])
-    if error_type == "value_error.missing":
-        return f"{loc} is a required property"
-    elif error_type == "value_error.extra":
-        return f"Additional properties are not allowed ({loc} was unexpected)"
-    else:
-        msg = e.get("msg", "unknown error")
-        return f"{loc}: {msg}"
-
-
 def validate_rules_db(rules_db: Dict[str, Any]) -> RulesDbSchema:
     """Validate rule is valid."""
     try:
@@ -76,8 +65,7 @@ def validate_rules_db(rules_db: Dict[str, Any]) -> RulesDbSchema:
         _log_error_and_exit(
             "Rules db is invalid: "
             + "\t\n".join(
-                _format_validation_error(cast(dict[str, Any], err))
-                for err in e.errors()
+                format_validation_error(cast(dict[str, Any], err)) for err in e.errors()
             )
         )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -594,28 +594,6 @@ plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
-name = "jsonschema"
-version = "3.2.0"
-description = "An implementation of JSON Schema validation for Python"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
-    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
-]
-
-[package.dependencies]
-attrs = ">=17.4.0"
-pyrsistent = ">=0.14.0"
-setuptools = "*"
-six = ">=1.11.0"
-
-[package.extras]
-format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
-format-nongpl = ["idna", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "webcolors"]
-
-[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
@@ -974,37 +952,6 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyrsistent"
-version = "0.18.1"
-description = "Persistent/Functional/Immutable data structures"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
-    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
-    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
-    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
-    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
-    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
-    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
-    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
-    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
-    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
-    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
-    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
-    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
-    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
-    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
-    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
-    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
-    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
-    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
-    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
-    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
-]
-
-[[package]]
 name = "pytest"
 version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
@@ -1170,27 +1117,10 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "setuptools"
-version = "65.5.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
-    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
@@ -1442,4 +1372,4 @@ testing = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "572224e36649fd8286acb6f58babae82db66ab6a0059191a6de2da2f2a3527ce"
+content-hash = "ba42239bee19a1982f058b5c844574d0da03516d359504978b0500239a111868"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ include = ["boostsec/registry_validator/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-jsonschema = "^3.2.0"
 PyYAML = "^6.0"
 requests = "^2.28.1"
 gql = {extras = ["requests"], version = "^3.4.0"}
@@ -37,7 +36,6 @@ flake8-isort = "^4.1.1"
 flake8-logging-format = "^0.6.0"
 flake8-pytest-style = "^1.5.1"
 isort = "^5.10.1"
-jsonschema = "^3.2.0"
 mypy = "^0.921"
 pep8-naming = "^0.12.1"
 pytest = "^7.0.1"

--- a/tests/integration/test_validate_namespace.py
+++ b/tests/integration/test_validate_namespace.py
@@ -1,5 +1,4 @@
 """Validate namespaces integration tests."""
-import re
 from pathlib import Path
 
 import pytest
@@ -71,7 +70,8 @@ def test_main_invalid_module(
     registry_path: Path, cli_runner: CliRunner, use_sample: UseSample
 ) -> None:
     """Test main with repeated namespaces."""
-    use_sample("scanners/invalids/missing-namespace")
+    sample = "scanners/invalids/missing-namespace"
+    use_sample(sample)
     result = cli_runner.invoke(
         app,
         [
@@ -80,4 +80,7 @@ def test_main_invalid_module(
         ],
     )
     assert result.exit_code == 1
-    assert len(re.findall(r"ERROR: .* is a required property in", result.stdout)) == 1
+    assert (
+        f"ERROR: {registry_path/sample/'module.yaml'} is invalid:"
+        " namespace is a required property" in result.stdout
+    )

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,29 @@
+"""Errors unit tests."""
+
+from typing import Any
+
+import pytest
+
+from boostsec.registry_validator.errors import format_validation_error
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (
+            {"loc": ["obj", "field", "sub-field"], "type": "value_error.missing"},
+            "obj.field.sub-field is a required property",
+        ),
+        (
+            {"loc": ["field"], "type": "value_error.extra"},
+            "Additional properties are not allowed (field was unexpected)",
+        ),
+        (
+            {"loc": ["field"], "type": "not-handled"},
+            "field: unknown error",
+        ),
+    ],
+)
+def test_format_validation_error(error: dict[str, Any], expected: str) -> None:
+    """Should return expected message based on error type."""
+    assert format_validation_error(error) == expected


### PR DESCRIPTION
Like what was done for the rules and rules db, the schema & validation was converted to a pydantic model. Package `jsonschema` was also removed since it is no longer used.

New module `errors` was created to share conversion of pydantic validation errors. I plan to improve the overall errors handling in a future pr.