### PR TITLE
BST-6070: Validate server-side scanners

### DIFF
--- a/boostsec/registry_validator/config.py
+++ b/boostsec/registry_validator/config.py
@@ -12,6 +12,7 @@ class RegistryConfig(BaseModel):
 
     scanners_path: Path
     rules_realm_path: Path
+    server_side_scanners_path: Path
 
     @classmethod
     def from_registry(cls, registry_path: Path) -> "RegistryConfig":
@@ -19,4 +20,5 @@ class RegistryConfig(BaseModel):
         return cls(
             scanners_path=registry_path / "scanners",
             rules_realm_path=registry_path / "rules-realm",
+            server_side_scanners_path=registry_path / "server-side-scanners",
         )

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -2,7 +2,12 @@
 import os
 from typing import Any, Optional
 
-from pydantic import AnyHttpUrl, BaseModel, Field, root_validator, validator
+from pydantic import AnyHttpUrl, BaseModel, Field, validator
+
+
+class _ModuleBaseSchema(BaseModel):
+    name: str
+    namespace: str
 
 
 class ModuleConfigSchema(BaseModel):
@@ -11,25 +16,17 @@ class ModuleConfigSchema(BaseModel):
     support_diff_scan: bool
 
 
-class ModuleSchema(BaseModel):
+class ModuleSchema(_ModuleBaseSchema):
     """Representation of a module file content."""
 
     api_version: int
     id_: str = Field(..., alias="id")
-    name: str
-    namespace: str
-    server_side: Optional[bool]
     config: ModuleConfigSchema
-    steps: Optional[list[Any]]  # steps aren't currently validated
+    steps: list[Any]  # steps aren't currently validated
 
-    @root_validator
-    @classmethod
-    def validate_server_side(cls, field_values: dict[str, Any]) -> dict[str, Any]:
-        """Validate module without steps must be server-side."""
-        if not field_values.get("steps") and not field_values.get("server_side"):
-            raise ValueError("Module without steps must be server side.")
 
-        return field_values
+class ServerSideModuleSchema(_ModuleBaseSchema):
+    """Representation of a server-side module file content."""
 
 
 class RuleSchema(BaseModel):

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -5,7 +5,9 @@ from typing import Any, Optional
 from pydantic import AnyHttpUrl, BaseModel, Field, validator
 
 
-class _ModuleBaseSchema(BaseModel):
+class ModuleBaseSchema(BaseModel):
+    """Base for scanner modules."""
+
     name: str
     namespace: str
 
@@ -16,7 +18,7 @@ class ModuleConfigSchema(BaseModel):
     support_diff_scan: bool
 
 
-class ModuleSchema(_ModuleBaseSchema):
+class ModuleSchema(ModuleBaseSchema):
     """Representation of a module file content."""
 
     api_version: int
@@ -25,7 +27,7 @@ class ModuleSchema(_ModuleBaseSchema):
     steps: list[Any]  # steps aren't currently validated
 
 
-class ServerSideModuleSchema(_ModuleBaseSchema):
+class ServerSideModuleSchema(ModuleBaseSchema):
     """Representation of a server-side module file content."""
 
 

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -2,7 +2,7 @@
 import os
 from typing import Any, Optional
 
-from pydantic import AnyHttpUrl, BaseModel, Field, validator
+from pydantic import AnyHttpUrl, BaseModel, Field, root_validator, validator
 
 
 class ModuleConfigSchema(BaseModel):
@@ -18,8 +18,18 @@ class ModuleSchema(BaseModel):
     id_: str = Field(..., alias="id")
     name: str
     namespace: str
+    server_side: Optional[bool]
     config: ModuleConfigSchema
-    steps: list[Any]  # steps aren't currently validated
+    steps: Optional[list[Any]]  # steps aren't currently validated
+
+    @root_validator
+    @classmethod
+    def validate_server_side(cls, field_values: dict[str, Any]) -> dict[str, Any]:
+        """Validate module without steps must be server-side."""
+        if not field_values.get("steps") and not field_values.get("server_side"):
+            raise ValueError("Module without steps must be server side.")
+
+        return field_values
 
 
 class RuleSchema(BaseModel):

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -4,7 +4,12 @@ from typing import cast
 from pydantic_factories import ModelFactory, Use
 
 from boostsec.registry_validator.models import RuleRealmNamespace, ScannerNamespace
-from boostsec.registry_validator.schema import ModuleSchema, RuleSchema, RulesDbSchema
+from boostsec.registry_validator.schema import (
+    ModuleSchema,
+    RuleSchema,
+    RulesDbSchema,
+    ServerSideModuleSchema,
+)
 
 
 class ModuleSchemaFactory(ModelFactory[ModuleSchema]):
@@ -12,7 +17,11 @@ class ModuleSchemaFactory(ModelFactory[ModuleSchema]):
 
     __model__ = ModuleSchema
 
-    server_side = Use(lambda: False)
+
+class ServerSideModuleSchemaFactory(ModelFactory[ServerSideModuleSchema]):
+    """Factory."""
+
+    __model__ = ServerSideModuleSchema
 
 
 class RuleSchemaFactory(ModelFactory[RuleSchema]):

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -12,6 +12,8 @@ class ModuleSchemaFactory(ModelFactory[ModuleSchema]):
 
     __model__ = ModuleSchema
 
+    server_side = Use(lambda: False)
+
 
 class RuleSchemaFactory(ModelFactory[RuleSchema]):
     """Factory."""

--- a/boostsec/registry_validator/validate_namespaces.py
+++ b/boostsec/registry_validator/validate_namespaces.py
@@ -69,11 +69,14 @@ def validate_module_yaml_schema(module: Path) -> ModuleSchema:
 
 
 def validate_namespaces(
-    modules_list: list[ModuleSchema], rule_namespaces: list[str]
+    modules_list: list[ModuleSchema],
+    rule_namespaces: list[str],
+    server_modules: list[ModuleSchema],
 ) -> None:
     """Validate the namespaces are unique between modules & rules realm."""
     module_namespaces = get_module_namespaces(modules_list)
-    validate_unique_namespace(module_namespaces + rule_namespaces)
+    server_namespaces = get_module_namespaces(server_modules)
+    validate_unique_namespace(module_namespaces + rule_namespaces + server_namespaces)
 
 
 @app.command()
@@ -85,8 +88,10 @@ def main(
     print("Validating namespaces...")
     modules_list = find_module_yaml(config.scanners_path)
     rule_namespaces = find_rules_realm_namespace(config.rules_realm_path)
+    server_list = find_module_yaml(config.server_side_scanners_path)
     modules = [validate_module_yaml_schema(module) for module in modules_list]
-    validate_namespaces(modules, rule_namespaces)
+    server_modules = [validate_module_yaml_schema(module) for module in server_list]
+    validate_namespaces(modules, rule_namespaces, server_modules)
     print("Namespaces are unique.")
 
 

--- a/boostsec/registry_validator/validate_namespaces.py
+++ b/boostsec/registry_validator/validate_namespaces.py
@@ -1,7 +1,7 @@
 """Validates that namespaces are unique."""
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Union, cast
 
 import typer
 import yaml
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 from boostsec.registry_validator.config import RegistryConfig
 from boostsec.registry_validator.errors import format_validation_error
 from boostsec.registry_validator.parameters import RegistryPath
-from boostsec.registry_validator.schema import ModuleSchema
+from boostsec.registry_validator.schema import ModuleSchema, ServerSideModuleSchema
 
 app = typer.Typer()
 
@@ -37,7 +37,9 @@ def find_rules_realm_namespace(rules_realm_path: Path) -> list[str]:
     ]
 
 
-def get_module_namespaces(modules_list: list[ModuleSchema]) -> list[str]:
+def get_module_namespaces(
+    modules_list: Union[list[ModuleSchema], list[ServerSideModuleSchema]],
+) -> list[str]:
     """Return the namespaces for each modules."""
     return [module.namespace for module in modules_list]
 
@@ -68,10 +70,26 @@ def validate_module_yaml_schema(module: Path) -> ModuleSchema:
     return schema
 
 
+def validate_server_side_module(module: Path) -> ServerSideModuleSchema:
+    """Validate and load the module.yaml schema."""
+    module_yaml = yaml.safe_load(module.read_text())
+    try:
+        schema = ServerSideModuleSchema.parse_obj(module_yaml)
+    except ValidationError as e:
+        _log_error_and_exit(
+            f"{module} is invalid: "
+            + "\t\n".join(
+                format_validation_error(cast(dict[str, Any], err)) for err in e.errors()
+            )
+        )
+
+    return schema
+
+
 def validate_namespaces(
     modules_list: list[ModuleSchema],
     rule_namespaces: list[str],
-    server_modules: list[ModuleSchema],
+    server_modules: list[ServerSideModuleSchema],
 ) -> None:
     """Validate the namespaces are unique between modules & rules realm."""
     module_namespaces = get_module_namespaces(modules_list)
@@ -90,7 +108,7 @@ def main(
     rule_namespaces = find_rules_realm_namespace(config.rules_realm_path)
     server_list = find_module_yaml(config.server_side_scanners_path)
     modules = [validate_module_yaml_schema(module) for module in modules_list]
-    server_modules = [validate_module_yaml_schema(module) for module in server_list]
+    server_modules = [validate_server_side_module(module) for module in server_list]
     validate_namespaces(modules, rule_namespaces, server_modules)
     print("Namespaces are unique.")
 

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
@@ -1,11 +1,2 @@
-api_version: 1.0
-
-id: simple-scanner
 name: Simple Scanner
 namespace: boostsecurityio/simple-scanner
-server_side: true
-
-config:
-  support_diff_scan: true
-  require_full_repo: false
-

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
@@ -1,8 +1,9 @@
+
 api_version: 1.0
 
-id: simple-scanner
-name: Simple Scanner
-namespace: boostsecurityio/simple-scanner
+id: duplicate-module
+name: Duplicate Module
+namespace: invalids/duplicate-module
 server_side: true
 
 config:

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
@@ -1,12 +1,3 @@
-
-api_version: 1.0
-
-id: duplicate-module
 name: Duplicate Module
 namespace: invalids/duplicate-module
-server_side: true
-
-config:
-  support_diff_scan: true
-  require_full_repo: false
 

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
@@ -1,8 +1,9 @@
+
 api_version: 1.0
 
-id: simple-scanner
-name: Simple Scanner
-namespace: boostsecurityio/simple-scanner
+id: duplicate-module
+name: Duplicate Module
+namespace: invalids/duplicate-module
 server_side: true
 
 config:

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
@@ -1,12 +1,3 @@
-
-api_version: 1.0
-
-id: duplicate-module
 name: Duplicate Module
 namespace: invalids/duplicate-module
-server_side: true
-
-config:
-  support_diff_scan: true
-  require_full_repo: false
 

--- a/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
@@ -1,8 +1,8 @@
+
 api_version: 1.0
 
-id: simple-scanner
-name: Simple Scanner
-namespace: boostsecurityio/simple-scanner
+id: missing-namespace
+name: Missing Namespace
 server_side: true
 
 config:

--- a/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
@@ -1,11 +1,1 @@
-
-api_version: 1.0
-
-id: missing-namespace
 name: Missing Namespace
-server_side: true
-
-config:
-  support_diff_scan: true
-  require_full_repo: false
-

--- a/tests/unit/scanner/conftest.py
+++ b/tests/unit/scanner/conftest.py
@@ -34,8 +34,6 @@ def rules_realm_path(registry_path: Path) -> Path:
 
 
 @pytest.fixture()
-def registry_config(scanners_path: Path, rules_realm_path: Path) -> RegistryConfig:
+def registry_config(registry_path: Path) -> RegistryConfig:
     """Return a RegistryConfig from valid temporary paths."""
-    return RegistryConfig(
-        scanners_path=scanners_path, rules_realm_path=rules_realm_path
-    )
+    return RegistryConfig.from_registry(registry_path)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,3 +9,4 @@ def test_registry_config_from_path(tmp_path: Path) -> None:
     config = RegistryConfig.from_registry(tmp_path)
     assert config.scanners_path == tmp_path / "scanners"
     assert config.rules_realm_path == tmp_path / "rules-realm"
+    assert config.server_side_scanners_path == tmp_path / "server-side-scanners"

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1,30 +1,14 @@
 """Test for scanners & rules schemas."""
 
-from typing import Optional
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 
 from boostsec.registry_validator.testing.factories import (
-    ModuleSchemaFactory,
     RuleSchemaFactory,
     RulesDbSchemaFactory,
 )
-
-
-def test_validate_server_side_module() -> None:
-    """Server side scanner have optional steps."""
-    ModuleSchemaFactory.build(steps=None, server_side=True)
-
-
-@pytest.mark.parametrize("server_side", [None, False])
-def test_validate_module_missing_step(server_side: Optional[bool]) -> None:
-    """Should raises if a non server side scanner is missing steps."""
-    with pytest.raises(
-        ValidationError, match="Module without steps must be server side."
-    ):
-        ModuleSchemaFactory.build(steps=None, server_side=server_side)
 
 
 def test_validate_rule_name_with_valid_name() -> None:

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1,13 +1,30 @@
 """Test for scanners & rules schemas."""
 
+from typing import Optional
+
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 
 from boostsec.registry_validator.testing.factories import (
+    ModuleSchemaFactory,
     RuleSchemaFactory,
     RulesDbSchemaFactory,
 )
+
+
+def test_validate_server_side_module() -> None:
+    """Server side scanner have optional steps."""
+    ModuleSchemaFactory.build(steps=None, server_side=True)
+
+
+@pytest.mark.parametrize("server_side", [None, False])
+def test_validate_module_missing_step(server_side: Optional[bool]) -> None:
+    """Should raises if a non server side scanner is missing steps."""
+    with pytest.raises(
+        ValidationError, match="Module without steps must be server side."
+    ):
+        ModuleSchemaFactory.build(steps=None, server_side=server_side)
 
 
 def test_validate_rule_name_with_valid_name() -> None:


### PR DESCRIPTION
Added validation for the new server-side scanners. These scanners are almost identical to the regular scanner, but they don't have steps, must have `server_side: true`. Additional validation to the module schema was added to make sure that a module without rules must be set as server-side. Also, check that namespaces are unique across all scanners, server-side or not.