### PR TITLE
BST-6077: Upload server-side scanners

### DIFF
--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -267,10 +267,16 @@ def main(
     """Process a rule database."""
     config = RegistryConfig.from_registry(registry_path)
     updated_scanners = find_updated_namespaces(registry_path, config.scanners_path)
+    updated_server_scanners = find_updated_namespaces(
+        registry_path, config.server_side_scanners_path
+    )
+    updated_scanners = updated_scanners | updated_server_scanners
     updated_realms = find_updated_namespaces(registry_path, config.rules_realm_path)
     updated_ns = updated_scanners | updated_realms
 
     scanners = load_scanners(config.scanners_path, updated_ns)
+    server_scanners = load_scanners(config.server_side_scanners_path, updated_ns)
+    scanners = scanners + server_scanners
     rules_realm = load_rules_realm(config.rules_realm_path, updated_ns)
     namespace_cache = make_namespace_cache(scanners, rules_realm)
     scanners_to_update = get_updated_scanners(scanners, namespace_cache)

--- a/tests/integration/test_upload_rules_db.py
+++ b/tests/integration/test_upload_rules_db.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from urllib.parse import urljoin
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from requests_mock import Mocker
 from typer.testing import CliRunner
@@ -52,12 +53,20 @@ def test_main_no_module_to_update(
     assert result.stdout == "No module rules to update.\n"
 
 
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "scanners/boostsecurityio/simple-scanner",
+        "server-side-scanners/boostsecurityio/simple-scanner",
+    ],
+)
 def test_main_simple_scanner(
     cli_runner: CliRunner,
     registry_path: Path,
     requests_mock: Mocker,
     commit_changes: CommitChanges,
     use_sample: UseSample,
+    sample: str,
 ) -> None:
     """Should parse and upload boostsecurityio/simple-scanner."""
     url = "https://my_endpoint/"
@@ -68,7 +77,7 @@ def test_main_simple_scanner(
         },
     )
 
-    use_sample("scanners/boostsecurityio/simple-scanner/")
+    use_sample(sample)
     commit_changes()
 
     result = cli_runner.invoke(
@@ -120,12 +129,20 @@ def test_main_simple_scanner(
     )
 
 
+@pytest.mark.parametrize(
+    "sample",
+    [
+        "scanners/boostsecurityio/simple-scanner",
+        "server-side-scanners/boostsecurityio/simple-scanner",
+    ],
+)
 def test_main_only_import(
     cli_runner: CliRunner,
     registry_path: Path,
     requests_mock: Mocker,
     commit_changes: CommitChanges,
     use_sample: UseSample,
+    sample: str,
 ) -> None:
     """Test importing rules & default."""
     url = "https://my_endpoint/"
@@ -136,7 +153,7 @@ def test_main_only_import(
         },
     )
 
-    use_sample("scanners/boostsecurityio/simple-scanner/")
+    use_sample(sample)
     use_sample("rules-realm/boostsecurityio/mitre-cwe")
     commit_changes()
 
@@ -218,12 +235,16 @@ def test_main_only_import(
     }
 
 
+@pytest.mark.parametrize(
+    "sample", ["scanners/others/only-import", "server-side-scanners/others/only-import"]
+)
 def test_main_rule_update_trigger_upload(
     cli_runner: CliRunner,
     registry_path: Path,
     requests_mock: Mocker,
     commit_changes: CommitChanges,
     use_sample: UseSample,
+    sample: str,
 ) -> None:
     """Test updating an imported rule-realm should update module using it."""
     url = "https://my_endpoint/"
@@ -235,7 +256,7 @@ def test_main_rule_update_trigger_upload(
     )
 
     use_sample("scanners/boostsecurityio/simple-scanner/")
-    use_sample("scanners/others/only-import")
+    use_sample(sample)
     commit_changes()
 
     use_sample("rules-realm/boostsecurityio/mitre-cwe")
@@ -458,12 +479,17 @@ def test_main_with_placeholder(
     }
 
 
+@pytest.mark.parametrize(
+    "sample",
+    ["scanners/others/missing-rules", "server-side-scanners/others/missing-rules"],
+)
 def test_main_module_missing_rules(
     cli_runner: CliRunner,
     registry_path: Path,
     requests_mock: Mocker,
     commit_changes: CommitChanges,
     use_sample: UseSample,
+    sample: str,
 ) -> None:
     """Should warn and exit if a module is missing a rules db."""
     url = "https://my_endpoint/"
@@ -474,7 +500,7 @@ def test_main_module_missing_rules(
         },
     )
 
-    use_sample("scanners/others/missing-rules")
+    use_sample(sample)
     commit_changes()
 
     result = cli_runner.invoke(

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -16,7 +16,7 @@ from boostsec.registry_validator.testing.factories import (
     RulesDbSchemaFactory,
     ScannerNamespaceFactory,
 )
-from boostsec.registry_validator.upload_rules_db import (  # find_updated_scanners,
+from boostsec.registry_validator.upload_rules_db import (
     find_updated_namespaces,
     get_updated_scanners,
     load_rules_realm,


### PR DESCRIPTION
Detect changes & upload server-side the same way regular scanners are. Since there is no difference in how the server-side or regular scanners rules are handled, we only have to monitor an extra directory and process/upload the changed rules.