### PR TITLE
BST-6121: Validate scan types

### DIFF
--- a/boostsec/registry_validator/errors.py
+++ b/boostsec/registry_validator/errors.py
@@ -10,6 +10,14 @@ def format_validation_error(e: dict[str, Any]) -> str:
         return f"{loc} is a required property"
     elif error_type == "value_error.extra":
         return f"Additional properties are not allowed ({loc} was unexpected)"
+    elif error_type == "type_error.enum":
+        permitted = [str(enum.value) for enum in e["ctx"]["enum_values"]]
+        return (
+            f"{loc} has an invalid value; permitted values are: {', '.join(permitted)}"
+        )
+    elif error_type == "value_error.list.min_items":
+        min_items = e["ctx"]["limit_value"]
+        return f"{loc}: at least {min_items} item is required"
     else:
         msg = e.get("msg", "unknown error")
         return f"{loc}: {msg}"

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -1,8 +1,20 @@
 """Scanners & rules definition schemas."""
 import os
+from enum import Enum
 from typing import Any, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, Field, validator
+
+
+class ScanType(str, Enum):
+    """Security types that a scanner can claim it produces."""
+
+    CICD = "cicd"
+    METADATA = "metadata"
+    SAST = "sast"
+    SBOM = "sbom"
+    SCA = "sca"
+    SCA_CONTAINER = "sca_container"
 
 
 class ModuleBaseSchema(BaseModel):
@@ -10,6 +22,7 @@ class ModuleBaseSchema(BaseModel):
 
     name: str
     namespace: str
+    scan_types: list[ScanType] = Field(..., min_items=1)
 
 
 class ModuleConfigSchema(BaseModel):

--- a/boostsec/registry_validator/testing/factories.py
+++ b/boostsec/registry_validator/testing/factories.py
@@ -8,6 +8,7 @@ from boostsec.registry_validator.schema import (
     ModuleSchema,
     RuleSchema,
     RulesDbSchema,
+    ScanType,
     ServerSideModuleSchema,
 )
 
@@ -16,12 +17,14 @@ class ModuleSchemaFactory(ModelFactory[ModuleSchema]):
     """Factory."""
 
     __model__ = ModuleSchema
+    scan_types = Use(lambda: cast(list[ScanType], [ScanType.SAST]))
 
 
 class ServerSideModuleSchemaFactory(ModelFactory[ServerSideModuleSchema]):
     """Factory."""
 
     __model__ = ServerSideModuleSchema
+    scan_types = Use(lambda: cast(list[ScanType], [ScanType.SAST]))
 
 
 class RuleSchemaFactory(ModelFactory[RuleSchema]):

--- a/tests/integration/samples/scanners/boostsecurityio/simple-scanner/module.yaml
+++ b/tests/integration/samples/scanners/boostsecurityio/simple-scanner/module.yaml
@@ -3,6 +3,8 @@ api_version: 1.0
 id: simple-scanner
 name: Simple Scanner
 namespace: boostsecurityio/simple-scanner
+scan_types:
+  - sast
 
 config:
   support_diff_scan: true

--- a/tests/integration/samples/scanners/invalids/duplicate-a/module.yaml
+++ b/tests/integration/samples/scanners/invalids/duplicate-a/module.yaml
@@ -4,6 +4,8 @@ api_version: 1.0
 id: duplicate-module
 name: Duplicate Module
 namespace: invalids/duplicate-module
+scan_types:
+  - sast
 
 config:
   support_diff_scan: true

--- a/tests/integration/samples/scanners/invalids/duplicate-b/module.yaml
+++ b/tests/integration/samples/scanners/invalids/duplicate-b/module.yaml
@@ -4,6 +4,8 @@ api_version: 1.0
 id: duplicate-module
 name: Duplicate Module
 namespace: invalids/duplicate-module
+scan_types:
+  - sast
 
 config:
   support_diff_scan: true

--- a/tests/integration/samples/scanners/invalids/empty-rules/module.yaml
+++ b/tests/integration/samples/scanners/invalids/empty-rules/module.yaml
@@ -4,6 +4,8 @@ api_version: 1.0
 id: empty-rules
 name: Empty Rules
 namespace: invalids/empty-rules
+scan_types:
+  - sast
 
 config:
   support_diff_scan: true

--- a/tests/integration/samples/scanners/invalids/missing-namespace/module.yaml
+++ b/tests/integration/samples/scanners/invalids/missing-namespace/module.yaml
@@ -3,6 +3,8 @@ api_version: 1.0
 
 id: missing-namespace
 name: Missing Namespace
+scan_types:
+  - sast
 
 config:
   support_diff_scan: true

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
@@ -1,2 +1,4 @@
 name: Simple Scanner
 namespace: boostsecurityio/simple-scanner
+scan_types:
+  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
@@ -1,3 +1,4 @@
 name: Duplicate Module
 namespace: invalids/duplicate-module
-
+scan_types:
+  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
@@ -1,3 +1,5 @@
 name: Duplicate Module
 namespace: invalids/duplicate-module
+scan_types:
+  - sast
 

--- a/tests/integration/samples/server-side-scanners/invalids/empty-rules/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/empty-rules/module.yaml
@@ -1,2 +1,4 @@
 name: Empty Rules
 namespace: invalids/empty-rules
+scan_types:
+  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
@@ -1,1 +1,3 @@
 name: Missing Namespace
+scan_types:
+  - sast

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,10 +1,19 @@
 """Errors unit tests."""
 
+from enum import Enum
 from typing import Any
 
 import pytest
 
 from boostsec.registry_validator.errors import format_validation_error
+
+
+class DummyEnum(str, Enum):
+    """Dummy enum for testing."""
+
+    A = "a"
+    B = "b"
+    C = "c"
 
 
 @pytest.mark.parametrize(
@@ -17,6 +26,22 @@ from boostsec.registry_validator.errors import format_validation_error
         (
             {"loc": ["field"], "type": "value_error.extra"},
             "Additional properties are not allowed (field was unexpected)",
+        ),
+        (
+            {
+                "loc": ["field", "0"],
+                "type": "type_error.enum",
+                "ctx": {"enum_values": list(DummyEnum)},
+            },
+            "field.0 has an invalid value; permitted values are: a, b, c",
+        ),
+        (
+            {
+                "loc": ["field"],
+                "type": "value_error.list.min_items",
+                "ctx": {"limit_value": 1},
+            },
+            "field: at least 1 item is required",
         ),
         (
             {"loc": ["field"], "type": "not-handled"},

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1,14 +1,31 @@
 """Test for scanners & rules schemas."""
 
 
+from typing import Optional
+
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from pydantic import ValidationError
 
+from boostsec.registry_validator.schema import ScanType
 from boostsec.registry_validator.testing.factories import (
+    ModuleSchemaFactory,
     RuleSchemaFactory,
     RulesDbSchemaFactory,
 )
+
+
+def test_validate_scan_types() -> None:
+    """Test all scan types can be parsed."""
+    module = ModuleSchemaFactory.build(scan_types=[t.value for t in ScanType])
+    assert module.scan_types == list(ScanType)
+
+
+@pytest.mark.parametrize("scan_types", [None, ["unknown"]])
+def test_validate_invalid_scan_types(scan_types: Optional[list[str]]) -> None:
+    """Should reject invalid types or if types are missing."""
+    with pytest.raises(ValidationError):
+        ModuleSchemaFactory.build(scan_types=scan_types)
 
 
 def test_validate_rule_name_with_valid_name() -> None:


### PR DESCRIPTION
Scanners now needs to defined a scan types which needs to be one of the predefined possible values. A scanner can have multiple, but at least one is required.