### PR TITLE
BST-6424: Remove scan-types for server-side scanners

### DIFF
--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -22,7 +22,6 @@ class ModuleBaseSchema(BaseModel):
 
     name: str
     namespace: str
-    scan_types: list[ScanType] = Field(..., min_items=1)
 
 
 class ModuleConfigSchema(BaseModel):
@@ -38,6 +37,7 @@ class ModuleSchema(ModuleBaseSchema):
     id_: str = Field(..., alias="id")
     config: ModuleConfigSchema
     steps: list[Any]  # steps aren't currently validated
+    scan_types: list[ScanType] = Field(..., min_items=1)
 
 
 class ServerSideModuleSchema(ModuleBaseSchema):

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/module.yaml
@@ -1,4 +1,2 @@
 name: Simple Scanner
 namespace: boostsecurityio/simple-scanner
-scan_types:
-  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-a/module.yaml
@@ -1,4 +1,2 @@
 name: Duplicate Module
 namespace: invalids/duplicate-module
-scan_types:
-  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/duplicate-b/module.yaml
@@ -1,5 +1,2 @@
 name: Duplicate Module
 namespace: invalids/duplicate-module
-scan_types:
-  - sast
-

--- a/tests/integration/samples/server-side-scanners/invalids/empty-rules/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/empty-rules/module.yaml
@@ -1,4 +1,2 @@
 name: Empty Rules
 namespace: invalids/empty-rules
-scan_types:
-  - sast

--- a/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
+++ b/tests/integration/samples/server-side-scanners/invalids/missing-namespace/module.yaml
@@ -1,3 +1,1 @@
 name: Missing Namespace
-scan_types:
-  - sast


### PR DESCRIPTION
Server-side scanners scan-types are defined in the backend, having them defined in the module file is not needed.