### PR TITLE
BST-9548: add license scan-type

### DIFF
--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -18,6 +18,7 @@ class ScanType(str, Enum):
     SECRETS = "secrets"
     IAC = "iac"
     SCI = "sci"
+    LICENSE = "license"
 
 
 class ModuleBaseSchema(BaseModel):

--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -10,15 +10,15 @@ class ScanType(str, Enum):
     """Security types that a scanner can claim it produces."""
 
     CICD = "cicd"
+    IAC = "iac"
+    LICENSE = "license"
     METADATA = "metadata"
     SAST = "sast"
     SBOM = "sbom"
     SCA = "sca"
     SCA_CONTAINER = "sca_container"
-    SECRETS = "secrets"
-    IAC = "iac"
     SCI = "sci"
-    LICENSE = "license"
+    SECRETS = "secrets"
 
 
 class ModuleBaseSchema(BaseModel):


### PR DESCRIPTION
New scan-type 'license' for scanners that emits findings based on licenses found.

drive-by: sorted scan-type enums