### PR TITLE
BST-11165: allow imports from server-side scanner rules

### DIFF
--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -1,4 +1,5 @@
 """Uploads the Rules DB file."""
+
 import sys
 from pathlib import Path
 from subprocess import check_call, check_output
@@ -141,12 +142,16 @@ def load_rules_realm(
 
 
 def make_namespace_cache(
-    scanners: list[ScannerNamespace], rules_realm: list[RuleRealmNamespace]
+    scanners: list[ScannerNamespace],
+    rules_realm: list[RuleRealmNamespace],
+    server_side_scanners: list[ScannerNamespace],
 ) -> dict[str, NamespaceUnion]:
     """Create a map from scanners & rules realm with their namespace as key."""
-    return {scanner.namespace: scanner for scanner in scanners} | {
-        realm.namespace: realm for realm in rules_realm
-    }
+    return (
+        {scanner.namespace: scanner for scanner in server_side_scanners}
+        | {scanner.namespace: scanner for scanner in scanners}
+        | {realm.namespace: realm for realm in rules_realm}
+    )
 
 
 def rollup(
@@ -290,7 +295,7 @@ def main(
     server_scanners = load_scanners(config.server_side_scanners_path, updated_ns)
     scanners = scanners + server_scanners
     rules_realm = load_rules_realm(config.rules_realm_path, updated_ns)
-    namespace_cache = make_namespace_cache(scanners, rules_realm)
+    namespace_cache = make_namespace_cache(scanners, rules_realm, server_scanners)
     scanners_to_update = get_updated_scanners(scanners, namespace_cache)
 
     if len(scanners_to_update) == 0:

--- a/boostsec/registry_validator/validate_rules_db.py
+++ b/boostsec/registry_validator/validate_rules_db.py
@@ -1,4 +1,5 @@
 """Validates the Rules DB file."""
+
 import sys
 from itertools import chain
 from pathlib import Path
@@ -90,11 +91,14 @@ def _validate_imports(
 
     scanner_path = config.scanners_path / namespace / "rules.yaml"
     rules_realm_path = config.rules_realm_path / namespace / "rules.yaml"
+    server_scanner_path = config.server_side_scanners_path / namespace / "rules.yaml"
     data = {}
     if scanner_path.exists():
         data = load_yaml_file(scanner_path)
     elif rules_realm_path.exists():
         data = load_yaml_file(rules_realm_path)
+    elif server_scanner_path.exists():
+        data = load_yaml_file(server_scanner_path)
     else:
         _log_error_and_exit(f"Imported namespace {namespace} not found")
 

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/module.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/module.yaml
@@ -1,0 +1,2 @@
+name: Simple Server Scanner
+namespace: boostsecurityio/simple-server-scanner

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/rules.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/rules.yaml
@@ -1,0 +1,19 @@
+rules:
+  my-rule-1:
+    categories:
+      - ALL
+      - category-1
+    description: Lorem Ipsum
+    group: Test group 1
+    name: my-rule-1
+    pretty_name: My rule 1
+    ref: "http://my.link.com"
+  my-rule-2:
+    categories:
+      - ALL
+      - category-2
+    description: Lorem Ipsum
+    group: Test group 2
+    name: my-rule-2
+    pretty_name: My rule 2
+    ref: "http://my.link.com"

--- a/tests/integration/samples/server-side-scanners/others/only-import/rules.yaml
+++ b/tests/integration/samples/server-side-scanners/others/only-import/rules.yaml
@@ -1,3 +1,4 @@
 import:
   - boostsecurityio/mitre-cwe
   - boostsecurityio/simple-scanner
+  - boostsecurityio/simple-server-scanner

--- a/tests/integration/samples/server-side-scanners/others/only-server-import/module.yaml
+++ b/tests/integration/samples/server-side-scanners/others/only-server-import/module.yaml
@@ -1,0 +1,2 @@
+name: Only Server Import
+namespace: others/only-server-import

--- a/tests/integration/samples/server-side-scanners/others/only-server-import/rules.yaml
+++ b/tests/integration/samples/server-side-scanners/others/only-server-import/rules.yaml
@@ -1,0 +1,2 @@
+import:
+  - boostsecurityio/simple-server-scanner

--- a/tests/integration/test_upload_rules_db.py
+++ b/tests/integration/test_upload_rules_db.py
@@ -256,6 +256,7 @@ def test_main_rule_update_trigger_upload(
     )
 
     use_sample("scanners/boostsecurityio/simple-scanner/")
+    use_sample("server-side-scanners/boostsecurityio/simple-server-scanner/")
     use_sample(sample)
     commit_changes()
 

--- a/tests/integration/test_validate_rules_db.py
+++ b/tests/integration/test_validate_rules_db.py
@@ -1,4 +1,5 @@
 """Validate rules tests."""
+
 from pathlib import Path
 
 import pytest
@@ -38,6 +39,7 @@ def test_main_with_valid_rules(
     [
         "scanners/others/only-import",
         "server-side-scanners/others/only-import",
+        "server-side-scanners/others/only-server-import",
     ],
 )
 def test_main_with_valid_imports(
@@ -47,6 +49,7 @@ def test_main_with_valid_imports(
     use_sample(sample)
     use_sample("scanners/boostsecurityio/simple-scanner")
     use_sample("rules-realm/boostsecurityio/mitre-cwe")
+    use_sample("server-side-scanners/boostsecurityio/simple-server-scanner")
 
     result = cli_runner.invoke(
         app,

--- a/tests/integration/test_validate_rules_db.py
+++ b/tests/integration/test_validate_rules_db.py
@@ -66,6 +66,10 @@ def test_main_with_valid_imports(
     assert (
         "Validating rules-realm/boostsecurityio/mitre-cwe/rules.yaml\n" in result.stdout
     )
+    assert (
+        "Validating server-side-scanners/boostsecurityio/"
+        "simple-server-scanner/rules.yaml\n" in result.stdout
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -1,4 +1,5 @@
 """Test."""
+
 from pathlib import Path
 from subprocess import check_call
 from typing import Any, Optional
@@ -83,7 +84,8 @@ def _commit_all_changes(git_root: Path, message: str = "commit") -> None:
     """Commit all changes in the git_root repo."""
     check_call(["git", "add", "-A"], cwd=git_root)  # noqa: S603 S607 noboost
     check_call(  # noboost
-        ["git", "commit", "-am", message], cwd=git_root  # noqa: S603 S607
+        ["git", "commit", "-am", message],  # noqa: S603 S607
+        cwd=git_root,
     )
 
 
@@ -185,13 +187,17 @@ def test_make_namespace_cache() -> None:
     """
     scanners = ScannerNamespaceFactory.batch(2)
     realms = RuleRealmNamespaceFactory.batch(2)
-    cache = make_namespace_cache(scanners, realms)
+    server_scanners = ScannerNamespaceFactory.batch(2)
+    cache = make_namespace_cache(scanners, realms, server_scanners)
 
     for scanner in scanners:
         assert cache[scanner.namespace] == scanner
 
     for realm in realms:
         assert cache[realm.namespace] == realm
+
+    for scanner in server_scanners:
+        assert cache[scanner.namespace] == scanner
 
 
 def test_rollup() -> None:
@@ -213,7 +219,7 @@ def test_rollup() -> None:
     )
     n3 = ScannerNamespaceFactory.build(namespace="r3", imports=["r1", "r2"])
 
-    cache = make_namespace_cache([n1, n3], [n2])
+    cache = make_namespace_cache([n1, n3], [n2], [])
 
     n1_res = rollup(n1, cache)
     assert n1_res.rules == rules_1
@@ -253,7 +259,7 @@ def test_get_updated_scanners() -> None:
     )
     scanner_2 = ScannerNamespaceFactory.build(namespace="r3", imports=["r1", "r2"])
 
-    cache = make_namespace_cache([scanner_1, scanner_2], [rule_realm])
+    cache = make_namespace_cache([scanner_1, scanner_2], [rule_realm], [])
     result = get_updated_scanners([scanner_1, scanner_2], cache)
 
     assert len(result) == 1

--- a/tests/unit/scanner/test_validate_rules_db.py
+++ b/tests/unit/scanner/test_validate_rules_db.py
@@ -1,4 +1,5 @@
 """Test."""
+
 from pathlib import Path
 
 import pytest
@@ -375,6 +376,30 @@ def test_validate_rules_db_with_invalid_rules_db(
         validate_rules_db(yaml.safe_load(rule_str))
     out, _ = capfd.readouterr()
     assert out == "ERROR: Rules db is invalid: " + expected
+
+
+@pytest.mark.parametrize("source", ["scanners", "realm", "server-side"])
+def test_validate_imports(
+    source: str, capfd: pytest.CaptureFixture[str], registry_config: RegistryConfig
+) -> None:
+    """Should import the namespace from all 3 sources in the config."""
+    module = "namespace/module-a"
+    if source == "scanners":
+        _create_module_rules(
+            registry_config.scanners_path, module, VALID_RULES_DB_STRING
+        )
+    elif source == "realm":
+        _create_module_rules(
+            registry_config.rules_realm_path, module, VALID_RULES_DB_STRING
+        )
+    elif source == "server-side":
+        _create_module_rules(
+            registry_config.server_side_scanners_path, module, VALID_RULES_DB_STRING
+        )
+
+    validate_imports([module], registry_config)
+    out, _ = capfd.readouterr()
+    assert out == ""
 
 
 @pytest.mark.parametrize("from_realm", [True, False])


### PR DESCRIPTION
The server-side scanner were ignored in the import logic, so trying to import rules from another server-side scanner was always rejected in the validation step.