### PR TITLE
BST-13728 Add optional remediation for rules

### DIFF
--- a/boostsec/registry_validator/schema.py
+++ b/boostsec/registry_validator/schema.py
@@ -61,6 +61,7 @@ class RuleSchema(BaseModel):
     ref: AnyHttpUrl
 
     recommended: bool = False
+    remediation: Optional[str] = None
 
     class Config:
         """Config."""

--- a/boostsec/registry_validator/upload_rules_db.py
+++ b/boostsec/registry_validator/upload_rules_db.py
@@ -262,6 +262,7 @@ def upload_rules_db(
                             "prettyName": rule.pretty_name,
                             "ref": rule.ref,
                             "recommended": rule.recommended,
+                            "remediation": rule.remediation,
                         }
                         for rule in rules.values()
                     ],

--- a/tests/integration/samples/rules-realm/invalids/multi-defaults/rules.yaml
+++ b/tests/integration/samples/rules-realm/invalids/multi-defaults/rules.yaml
@@ -17,3 +17,4 @@ default:
     name: my-rule-2
     pretty_name: My rule 2
     ref: "http://my.link.com"
+    remediation: "Fix the issue"

--- a/tests/integration/samples/scanners/boostsecurityio/simple-scanner/rules.yaml
+++ b/tests/integration/samples/scanners/boostsecurityio/simple-scanner/rules.yaml
@@ -18,4 +18,4 @@ rules:
     name: my-rule-2
     pretty_name: My rule 2
     ref: "http://my.link.com"
- 
+    remediation: "Fix the issue"

--- a/tests/integration/samples/scanners/others/overload/rules.yaml
+++ b/tests/integration/samples/scanners/others/overload/rules.yaml
@@ -10,7 +10,7 @@ rules:
     name: CWE-1004
     pretty_name: 'CWE-1004: Overload'
     ref: https://cwe.mitre.org/data/definitions/1004.html
-  
+
 default:
   CWE-OVERLOAD:
     categories:

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/rules.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-scanner/rules.yaml
@@ -19,3 +19,4 @@ rules:
     pretty_name: My rule 2
     ref: "http://my.link.com"
     recommended: False
+    remediation: Fix the issue

--- a/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/rules.yaml
+++ b/tests/integration/samples/server-side-scanners/boostsecurityio/simple-server-scanner/rules.yaml
@@ -18,3 +18,4 @@ rules:
     name: my-rule-2
     pretty_name: My rule 2
     ref: "http://my.link.com"
+    remediation: Fix the issue

--- a/tests/integration/test_upload_rules_db.py
+++ b/tests/integration/test_upload_rules_db.py
@@ -109,6 +109,7 @@ def test_main_simple_scanner(
                     "prettyName": "My rule 1",
                     "ref": "http://my.link.com",
                     "recommended": True,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-2"],
@@ -119,6 +120,7 @@ def test_main_simple_scanner(
                     "prettyName": "My rule 2",
                     "ref": "http://my.link.com",
                     "recommended": False,
+                    "remediation": "Fix the issue",
                 },
             ],
         }
@@ -191,6 +193,7 @@ def test_main_only_import(
                     "prettyName": "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag",
                     "ref": "https://cwe.mitre.org/data/definitions/1004.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "boost-hardened"],
@@ -204,6 +207,7 @@ def test_main_only_import(
                     ),
                     "ref": "https://cwe.mitre.org/data/definitions/1007.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-1"],
@@ -214,6 +218,7 @@ def test_main_only_import(
                     "prettyName": "My rule 1",
                     "ref": "http://my.link.com",
                     "recommended": True,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-2"],
@@ -224,6 +229,7 @@ def test_main_only_import(
                     "prettyName": "My rule 2",
                     "ref": "http://my.link.com",
                     "recommended": False,
+                    "remediation": "Fix the issue",
                 },
                 {
                     "categories": ["ALL", "boost-hardened"],
@@ -236,6 +242,7 @@ def test_main_only_import(
                     ),
                     "ref": "https://cwe.mitre.org/",
                     "recommended": False,
+                    "remediation": None,
                 },
             ],
         }
@@ -299,6 +306,7 @@ def test_main_rule_update_trigger_upload(
                     "prettyName": "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag",
                     "ref": "https://cwe.mitre.org/data/definitions/1004.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "boost-hardened"],
@@ -312,6 +320,7 @@ def test_main_rule_update_trigger_upload(
                     ),
                     "ref": "https://cwe.mitre.org/data/definitions/1007.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-1"],
@@ -322,6 +331,7 @@ def test_main_rule_update_trigger_upload(
                     "prettyName": "My rule 1",
                     "ref": "http://my.link.com",
                     "recommended": True,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-2"],
@@ -332,6 +342,7 @@ def test_main_rule_update_trigger_upload(
                     "prettyName": "My rule 2",
                     "ref": "http://my.link.com",
                     "recommended": False,
+                    "remediation": "Fix the issue",
                 },
                 {
                     "categories": ["ALL", "boost-hardened"],
@@ -344,6 +355,7 @@ def test_main_rule_update_trigger_upload(
                     ),
                     "ref": "https://cwe.mitre.org/",
                     "recommended": False,
+                    "remediation": None,
                 },
             ],
         }
@@ -399,6 +411,7 @@ def test_main_rule_import_overload(
                     "prettyName": "CWE-1004: Overload",
                     "ref": "https://cwe.mitre.org/data/definitions/1004.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "boost-hardened"],
@@ -412,6 +425,7 @@ def test_main_rule_import_overload(
                     ),
                     "ref": "https://cwe.mitre.org/data/definitions/1007.html",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL"],
@@ -422,6 +436,7 @@ def test_main_rule_import_overload(
                     "prettyName": "CWE-OVERLOAD - Overload",
                     "ref": "https://cwe.mitre.org/",
                     "recommended": False,
+                    "remediation": None,
                 },
             ],
         }
@@ -481,6 +496,7 @@ def test_main_with_placeholder(
                     "prettyName": "My rule 1",
                     "ref": f"{doc_url}/a/b/c",
                     "recommended": False,
+                    "remediation": None,
                 },
                 {
                     "categories": ["ALL", "category-2"],
@@ -491,6 +507,7 @@ def test_main_with_placeholder(
                     "prettyName": "My rule 2",
                     "ref": f"{doc_url}/d/e/f",
                     "recommended": False,
+                    "remediation": None,
                 },
             ],
         },

--- a/tests/unit/scanner/test_upload_rules_db.py
+++ b/tests/unit/scanner/test_upload_rules_db.py
@@ -321,6 +321,7 @@ def test_upload_rules_db(requests_mock: Mocker, with_default: bool) -> None:
                         "prettyName": rule.pretty_name,
                         "ref": rule.ref,
                         "recommended": rule.recommended,
+                        "remediation": rule.remediation,
                     }
                     for rule in rules
                 ],


### PR DESCRIPTION
The remediation allows for specific text to be added to a rule to
explain how it should be fixed. This is primarly useful for CI/CD
settings since their remediation is known and constant with the rule
that is being enforced.